### PR TITLE
Add schema and stored procedure scripts

### DIFF
--- a/sql/fork_session.sql
+++ b/sql/fork_session.sql
@@ -1,0 +1,28 @@
+-- fork_session: creates a new environment from a command snapshot
+-- Refers to SPEC.md for snapshot fields and AGENTS.md for replay_agent usage
+
+CREATE OR REPLACE FUNCTION fork_session(p_user_id UUID, p_source_command_id INTEGER)
+RETURNS UUID LANGUAGE plpgsql AS $$
+DECLARE
+  src RECORD;
+BEGIN
+  SELECT cwd_snapshot, env_snapshot
+    INTO src
+    FROM commands
+    WHERE id = p_source_command_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'source command % not found', p_source_command_id;
+  END IF;
+
+  INSERT INTO environments(user_id, cwd, env)
+    VALUES (p_user_id,
+            COALESCE(src.cwd_snapshot, '/home/sandbox'),
+            COALESCE(src.env_snapshot, '{}'::jsonb))
+    ON CONFLICT (user_id) DO UPDATE
+      SET cwd = EXCLUDED.cwd,
+          env = EXCLUDED.env,
+          updated_at = now();
+
+  RETURN p_user_id;
+END;
+$$;

--- a/sql/init_schema.sql
+++ b/sql/init_schema.sql
@@ -1,0 +1,27 @@
+-- Schema initialization for pg_shell
+-- Tables defined per SPEC.md
+
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS environments (
+  user_id UUID PRIMARY KEY REFERENCES users(id),
+  cwd TEXT NOT NULL DEFAULT '/home/sandbox',
+  env JSONB NOT NULL DEFAULT '{}',
+  updated_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS commands (
+  id SERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id),
+  command TEXT NOT NULL,
+  submitted_at TIMESTAMP NOT NULL DEFAULT now(),
+  status TEXT NOT NULL DEFAULT 'pending',
+  output TEXT,
+  exit_code INT,
+  cwd_snapshot TEXT,
+  env_snapshot JSONB,
+  CONSTRAINT status_enum CHECK (status IN ('pending','running','done','failed'))
+);

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -1,0 +1,5 @@
+-- install.sql: convenience script to install pg_shell schema and functions
+\i sql/init_schema.sql
+\i sql/submit_command.sql
+\i sql/latest_output.sql
+\i sql/fork_session.sql

--- a/sql/latest_output.sql
+++ b/sql/latest_output.sql
@@ -1,0 +1,18 @@
+-- latest_output: returns recent commands and outputs
+-- Based on SPEC.md RPC definition
+
+CREATE OR REPLACE FUNCTION latest_output(p_user_id UUID)
+RETURNS TABLE(
+    id INTEGER,
+    command TEXT,
+    output TEXT,
+    exit_code INT,
+    status TEXT,
+    submitted_at TIMESTAMP
+) LANGUAGE sql AS $$
+    SELECT id, command, output, exit_code, status, submitted_at
+    FROM commands
+    WHERE user_id = $1
+    ORDER BY id DESC
+    LIMIT 20;
+$$;

--- a/sql/submit_command.sql
+++ b/sql/submit_command.sql
@@ -1,0 +1,23 @@
+-- submit_command: queues a command for execution
+-- References SPEC.md (RPC function) and executor_agent in AGENTS.md
+
+CREATE OR REPLACE FUNCTION submit_command(p_user_id UUID, p_command TEXT)
+RETURNS INTEGER LANGUAGE plpgsql AS $$
+DECLARE
+  env_row environments%ROWTYPE;
+  new_id INTEGER;
+BEGIN
+  -- ensure environment row exists
+  SELECT * INTO env_row FROM environments WHERE user_id = p_user_id;
+  IF NOT FOUND THEN
+    INSERT INTO environments(user_id) VALUES (p_user_id)
+      RETURNING * INTO env_row;
+  END IF;
+
+  INSERT INTO commands(user_id, command, cwd_snapshot, env_snapshot)
+    VALUES (p_user_id, p_command, env_row.cwd, env_row.env)
+    RETURNING id INTO new_id;
+
+  RETURN new_id;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add SQL scripts for DB schema and functions
- implement submit_command, latest_output, and fork_session stored procs
- provide install.sql to load the schema and procs easily

## Testing
- `psql --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6bac5f9883289192532420e3cfac