### PR TITLE
Improve CLI and setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Virtual environment
+venv/
+.env
+
+# Logs
+*.log
+
+# Misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ The frontend is a simple HTML+htmx app; no JavaScript-heavy terminal emulators, 
 -- Installs pg_shell PL/pgSQL functions and extensions
 ```
 
+**2. Install Python requirements**
+```bash
+pip install -r requirements.txt
+```
+
+**3. Run the executor agent**
+```bash
+DATABASE_URL=postgresql://localhost/postgres python workers/executor_agent.py
+```
+
+You can run `cleanup_agent.py` periodically and use `replay_agent.py` for
+session replays.
+
 ## Serving the HTML UI
 
 The `html/` directory contains a minimal `index.html` using htmx. Any

--- a/cli/shell_cli.py
+++ b/cli/shell_cli.py
@@ -28,8 +28,11 @@ def replay_session(base_url: str, session: str) -> None:
     print(data)
 
 
-def tail_output(base_url: str, user_id: str, interval: float = 1.0) -> None:
-    last_id: Any = None
+def tail_output(
+    base_url: str, user_id: str, interval: float = 1.0, since: int | None = None
+) -> None:
+    """Poll for new output and print it continuously."""
+    last_id: Any = since
     try:
         while True:
             params = {"user_id": f"eq.{user_id}"}
@@ -67,6 +70,7 @@ def main(argv: list[str] | None = None) -> int:
     tail_p = sub.add_parser("tail", help="Tail latest output")
     tail_p.add_argument("--user", required=True, help="User ID")
     tail_p.add_argument("--interval", type=float, default=1.0, help="Polling interval seconds")
+    tail_p.add_argument("--since", type=int, help="Start tailing after this command ID")
 
     args = parser.parse_args(argv)
 
@@ -77,7 +81,7 @@ def main(argv: list[str] | None = None) -> int:
     elif args.command == "fork":
         fork_session(args.base_url, args.user, args.at)
     elif args.command == "tail":
-        tail_output(args.base_url, args.user, args.interval)
+        tail_output(args.base_url, args.user, args.interval, args.since)
     else:
         parser.print_help()
         return 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+psycopg2-binary
+requests


### PR DESCRIPTION
## Summary
- add `.gitignore` for common Python artifacts
- document running agents and requirements
- support starting point in `tail` command via new `--since` option
- list minimal Python dependencies

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d8d8c7c788328aee3f994dafa02cd