### PR TITLE
Use subprocess.run with safe command parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ pip install -r requirements.txt
 DATABASE_URL=postgresql://localhost/postgres python workers/executor_agent.py
 ```
 Set `COMMAND_TIMEOUT` (seconds) to limit how long each command may run.
+Commands are parsed with `shlex.split` before execution, so quoting rules follow
+POSIX shells but features like glob expansion are not performed.
 
 You can run `cleanup_agent.py` periodically and use `replay_agent.py` for
 session replays.

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -9,6 +9,7 @@ implementation uses ``psycopg2`` and ``subprocess``. It also listens for the
 import json
 import os
 import select
+import shlex
 import subprocess
 import time
 from typing import Any, Dict
@@ -83,21 +84,21 @@ def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]
             env.update(json.loads(env_snapshot))
         else:
             env.update(env_snapshot)
-    proc = subprocess.Popen(
-        command,
-        shell=True,
-        cwd=cwd,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
+
+    cmd_list = shlex.split(command)
     try:
-        out, _ = proc.communicate(timeout=COMMAND_TIMEOUT)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        out, _ = proc.communicate()
-        return 124, f"Timed out after {COMMAND_TIMEOUT}s\n" + out.decode()
-    return proc.returncode, out.decode()
+        proc = subprocess.run(
+            cmd_list,
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=COMMAND_TIMEOUT,
+        )
+        return proc.returncode, proc.stdout
+    except subprocess.TimeoutExpired as exc:
+        output = exc.stdout or ""
+        return 124, f"Timed out after {COMMAND_TIMEOUT}s\n" + output
 
 
 def handle_command(conn, row: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- replace `subprocess.Popen` with `subprocess.run`
- parse command with `shlex.split` and execute without shell
- document new command parsing behavior

## Testing
- `python -m py_compile workers/executor_agent.py cli/shell_cli.py workers/cleanup_agent.py workers/replay_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_686fd751307c8328af51800f4e34f35c