### PR TITLE
Add completed_at tracking

### DIFF
--- a/sql/init_schema.sql
+++ b/sql/init_schema.sql
@@ -23,5 +23,6 @@ CREATE TABLE IF NOT EXISTS commands (
   exit_code INT,
   cwd_snapshot TEXT,
   env_snapshot JSONB,
+  completed_at TIMESTAMP,
   CONSTRAINT status_enum CHECK (status IN ('pending','running','done','failed'))
 );

--- a/sql/latest_output.sql
+++ b/sql/latest_output.sql
@@ -1,6 +1,8 @@
 -- latest_output: returns recent commands and outputs
 -- Based on SPEC.md RPC definition
 
+DROP FUNCTION IF EXISTS latest_output(UUID);
+
 CREATE OR REPLACE FUNCTION latest_output(p_user_id UUID)
 RETURNS TABLE(
     id INTEGER,
@@ -8,9 +10,10 @@ RETURNS TABLE(
     output TEXT,
     exit_code INT,
     status TEXT,
-    submitted_at TIMESTAMP
+    submitted_at TIMESTAMP,
+    completed_at TIMESTAMP
 ) LANGUAGE sql AS $$
-    SELECT id, command, output, exit_code, status, submitted_at
+    SELECT id, command, output, exit_code, status, submitted_at, completed_at
     FROM commands
     WHERE user_id = $1
     ORDER BY id DESC

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -38,11 +38,12 @@ def test_submit_and_latest_output(conn):
         cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (user_id, "testuser"))
         cur.execute("SELECT submit_command(%s, %s)", (user_id, "echo hello"))
         cmd_id = cur.fetchone()[0]
-        cur.execute("UPDATE commands SET output='hello', exit_code=0, status='done' WHERE id=%s", (cmd_id,))
+        cur.execute("UPDATE commands SET output='hello', exit_code=0, status='done', completed_at=now() WHERE id=%s", (cmd_id,))
         cur.execute("SELECT * FROM latest_output(%s)", (user_id,))
         row = cur.fetchone()
         assert row[0] == cmd_id
         assert row[2] == 'hello'
+        assert row[6] is not None
 
 
 def test_fork_session(conn):

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -65,7 +65,7 @@ def fetch_pending(conn) -> Dict[str, Any] | None:
 def update_command(conn, cmd_id: int, status: str, output: str, exit_code: int) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "UPDATE commands SET status=%s, output=%s, exit_code=%s WHERE id=%s",
+            "UPDATE commands SET status=%s, output=%s, exit_code=%s, completed_at=now() WHERE id=%s",
             (status, output, exit_code, cmd_id),
         )
     conn.commit()

--- a/workers/monitor_agent.py
+++ b/workers/monitor_agent.py
@@ -36,9 +36,9 @@ def collect_metrics(conn) -> Iterable[Row]:
             SELECT user_id,
                    DATE(submitted_at) AS day,
                    COUNT(*) AS command_count,
-                   AVG(EXTRACT(EPOCH FROM NOW() - submitted_at)) AS avg_seconds
-              FROM commands
-             WHERE status IN ('done', 'failed')
+                   AVG(EXTRACT(EPOCH FROM completed_at - submitted_at)) AS avg_seconds
+             FROM commands
+             WHERE status IN ('done', 'failed') AND completed_at IS NOT NULL
           GROUP BY user_id, day
           ORDER BY day, user_id
             """


### PR DESCRIPTION
## Summary
- add completed_at column to schema
- expose completed_at in latest_output
- mark commands complete in executor_agent
- use completed_at for metrics
- update tests for new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687051b63464832891acc8b1a74106fe