### PR TITLE
Use psycopg2 Identifier for LISTEN channel

### DIFF
--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -20,6 +20,7 @@ from typing import Any, Dict
 import logging
 
 import psycopg2
+from psycopg2 import sql
 from psycopg2.extras import RealDictCursor
 
 POLL_INTERVAL = float(os.getenv("POLL_INTERVAL", "1"))
@@ -38,7 +39,7 @@ def get_conn():
 
 def setup_listener(conn):
     with conn.cursor() as cur:
-        cur.execute("LISTEN %s;" % LISTEN_CHANNEL)
+        cur.execute(sql.SQL("LISTEN {}").format(sql.Identifier(LISTEN_CHANNEL)))
     conn.commit()
 
 


### PR DESCRIPTION
## Summary
- use `psycopg2.sql.Identifier` to safely compose `LISTEN` query in executor agent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689395ecc514832882688af73fe1ccbe