### PR TITLE
Add configurable HTTP timeout for shell CLI

### DIFF
--- a/cli/shell_cli.py
+++ b/cli/shell_cli.py
@@ -14,7 +14,10 @@ from typing import Any
 import requests
 
 
-def exec_command(base_url: str, user_id: str, cmd: str) -> None:
+DEFAULT_TIMEOUT = float(os.getenv("PG_SHELL_TIMEOUT", "30"))
+
+
+def exec_command(base_url: str, user_id: str, cmd: str, timeout: float = DEFAULT_TIMEOUT) -> None:
     """Submit a command for execution.
 
     Parameters
@@ -25,6 +28,8 @@ def exec_command(base_url: str, user_id: str, cmd: str) -> None:
         Identifier of the target user.
     cmd : str
         Command text to queue for execution.
+    timeout : float, optional
+        HTTP request timeout seconds.
 
     Returns
     -------
@@ -34,13 +39,14 @@ def exec_command(base_url: str, user_id: str, cmd: str) -> None:
     resp = requests.post(
         f"{base_url}/rpc/submit_command",
         json={"user_id": user_id, "command": cmd},
+        timeout=timeout,
     )
     resp.raise_for_status()
     data = resp.json()
     print(data)
 
 
-def fork_session(base_url: str, user_id: str, command_id: int) -> None:
+def fork_session(base_url: str, user_id: str, command_id: int, timeout: float = DEFAULT_TIMEOUT) -> None:
     """Create a new session starting from a previous command.
 
     Parameters
@@ -51,6 +57,8 @@ def fork_session(base_url: str, user_id: str, command_id: int) -> None:
         User owning the new session.
     command_id : int
         Identifier of the command to fork at.
+    timeout : float, optional
+        HTTP request timeout seconds.
 
     Returns
     -------
@@ -60,13 +68,14 @@ def fork_session(base_url: str, user_id: str, command_id: int) -> None:
     resp = requests.post(
         f"{base_url}/rpc/fork_session",
         json={"user_id": user_id, "source_command_id": command_id},
+        timeout=timeout,
     )
     resp.raise_for_status()
     data = resp.json()
     print(data)
 
 
-def replay_session(base_url: str, session: str) -> None:
+def replay_session(base_url: str, session: str, timeout: float = DEFAULT_TIMEOUT) -> None:
     """Request a replay of a past session.
 
     Parameters
@@ -75,6 +84,8 @@ def replay_session(base_url: str, session: str) -> None:
         PostgREST base URL.
     session : str
         Timestamp or session ID to replay.
+    timeout : float, optional
+        HTTP request timeout seconds.
 
     Returns
     -------
@@ -84,6 +95,7 @@ def replay_session(base_url: str, session: str) -> None:
     resp = requests.post(
         f"{base_url}/rpc/replay_session",
         json={"session": session},
+        timeout=timeout,
     )
     resp.raise_for_status()
     data = resp.json()
@@ -91,14 +103,20 @@ def replay_session(base_url: str, session: str) -> None:
 
 
 def tail_output(
-    base_url: str, user_id: str, interval: float = 1.0, since: int | None = None
+    base_url: str,
+    user_id: str,
+    interval: float = 1.0,
+    since: int | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
 ) -> None:
     """Poll for new output and print it continuously."""
     last_id: Any = since
     try:
         while True:
             params = {"user_id": f"eq.{user_id}"}
-            resp = requests.get(f"{base_url}/rpc/latest_output", params=params)
+            resp = requests.get(
+                f"{base_url}/rpc/latest_output", params=params, timeout=timeout
+            )
             resp.raise_for_status()
             rows = resp.json()
             for row in rows:
@@ -128,7 +146,17 @@ def main(argv: list[str] | None = None) -> int:
     """
 
     parser = argparse.ArgumentParser(description="pg_shell CLI")
-    parser.add_argument("--base-url", default=os.getenv("PG_SHELL_API", "http://localhost:3000"), help="PostgREST base URL")
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("PG_SHELL_API", "http://localhost:3000"),
+        help="PostgREST base URL",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT,
+        help="HTTP request timeout seconds",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     exec_p = sub.add_parser("exec", help="Submit a command")
@@ -150,13 +178,13 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "exec":
-        exec_command(args.base_url, args.user, args.cmd)
+        exec_command(args.base_url, args.user, args.cmd, args.timeout)
     elif args.command == "replay":
-        replay_session(args.base_url, args.session)
+        replay_session(args.base_url, args.session, args.timeout)
     elif args.command == "fork":
-        fork_session(args.base_url, args.user, args.at)
+        fork_session(args.base_url, args.user, args.at, args.timeout)
     elif args.command == "tail":
-        tail_output(args.base_url, args.user, args.interval, args.since)
+        tail_output(args.base_url, args.user, args.interval, args.since, args.timeout)
     else:
         parser.print_help()
         return 1


### PR DESCRIPTION
## Summary
- pass timeout to all HTTP requests
- allow configuring request timeout via `--timeout` CLI arg or `PG_SHELL_TIMEOUT`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689395ea04c0832895ca29b2ab171f3e