### PR TITLE
Use TEST_DATABASE_URL in cleanup agent tests

### DIFF
--- a/tests/test_cleanup_agent.py
+++ b/tests/test_cleanup_agent.py
@@ -1,51 +1,53 @@
-import subprocess
+import os
 import uuid
+from pathlib import Path
+
 import psycopg2
+import pytest
 
 from workers.cleanup_agent import cleanup_once
 
 
-def init_db(conn):
-    with conn.cursor() as cur:
-        cur.execute("DROP TABLE IF EXISTS commands")
-        cur.execute("DROP TABLE IF EXISTS environments")
-        cur.execute("DROP TABLE IF EXISTS users")
-        cur.execute("CREATE TABLE users (id uuid PRIMARY KEY)")
-        cur.execute(
-            "CREATE TABLE environments (user_id uuid PRIMARY KEY, cwd text NOT NULL, env jsonb NOT NULL, updated_at timestamp NOT NULL)"
-        )
-        cur.execute(
-            "CREATE TABLE commands (id serial PRIMARY KEY, user_id uuid, command text, submitted_at timestamp, status text)"
-        )
-    conn.commit()
+INIT_SQL = Path("sql/init_schema.sql").read_text()
 
 
-def test_cleanup_once_resets_env():
-    subprocess.run(["service", "postgresql", "start"], check=False)
-    subprocess.run(
-        ["sudo", "-u", "postgres", "createdb", "-O", "root", "pgshell_test"],
-        check=False,
-    )
-    conn = psycopg2.connect(dbname="pgshell_test", user="root")
-    init_db(conn)
+@pytest.fixture(scope="module")
+def conn():
+    dsn = os.environ.get("TEST_DATABASE_URL")
+    if not dsn:
+        pytest.skip("TEST_DATABASE_URL not set")
+    conn = psycopg2.connect(dsn)
+    conn.autocommit = True
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS commands, environments, users CASCADE;")
+    cur.execute(INIT_SQL)
+    cur.close()
+    yield conn
+    cur = conn.cursor()
+    cur.execute("DROP TABLE commands, environments, users CASCADE;")
+    cur.close()
+    conn.close()
+
+
+def test_cleanup_once_resets_env(conn):
     uid_str = str(uuid.uuid4())
     with conn.cursor() as cur:
-        cur.execute("INSERT INTO users (id) VALUES (%s)", (uid_str,))
+        cur.execute("INSERT INTO users (id, username) VALUES (%s, %s)", (uid_str, "testuser"))
         cur.execute(
-            "INSERT INTO environments (user_id, cwd, env, updated_at) VALUES (%s, '/tmp', %s::jsonb, now() - interval '100 days')",
-            (uid_str, '{"k":1}'),
+            "INSERT INTO environments (user_id, cwd, env, updated_at) VALUES (%s, %s, %s::jsonb, now() - interval '100 days')",
+            (uid_str, '/tmp', '{"k":1}'),
         )
         cur.execute(
             "INSERT INTO commands (user_id, command, submitted_at, status) VALUES (%s, 'ls', now() - interval '100 days', 'done')",
             (uid_str,),
         )
-    conn.commit()
 
     cleanup_once(conn, 90)
 
     with conn.cursor() as cur:
         cur.execute("SELECT cwd, env FROM environments WHERE user_id = %s", (uid_str,))
         cwd, env = cur.fetchone()
-    conn.close()
+
     assert cwd == '/home/sandbox'
     assert env == {}
+


### PR DESCRIPTION
## Summary
- Replace manual PostgreSQL setup in cleanup agent test with fixture using SQL schema files
- Use `TEST_DATABASE_URL` for database connection and skip when missing
- Remove subprocess-based database management from tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d277b56f083288d29272b9ddb7802