### PR TITLE
Handle request errors in shell CLI

### DIFF
--- a/cli/shell_cli.py
+++ b/cli/shell_cli.py
@@ -17,7 +17,9 @@ import requests
 DEFAULT_TIMEOUT = float(os.getenv("PG_SHELL_TIMEOUT", "30"))
 
 
-def exec_command(base_url: str, user_id: str, cmd: str, timeout: float = DEFAULT_TIMEOUT) -> None:
+def exec_command(
+    base_url: str, user_id: str, cmd: str, timeout: float = DEFAULT_TIMEOUT
+) -> int:
     """Submit a command for execution.
 
     Parameters
@@ -33,20 +35,29 @@ def exec_command(base_url: str, user_id: str, cmd: str, timeout: float = DEFAULT
 
     Returns
     -------
-    None
+    int
+        Status code, ``0`` on success, non-zero on failure.
     """
 
-    resp = requests.post(
-        f"{base_url}/rpc/submit_command",
-        json={"user_id": user_id, "command": cmd},
-        timeout=timeout,
-    )
-    resp.raise_for_status()
+    try:
+        resp = requests.post(
+            f"{base_url}/rpc/submit_command",
+            json={"user_id": user_id, "command": cmd},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        print(f"submit failed: {exc}", file=sys.stderr)
+        return 1
+
     data = resp.json()
     print(data)
+    return 0
 
 
-def fork_session(base_url: str, user_id: str, command_id: int, timeout: float = DEFAULT_TIMEOUT) -> None:
+def fork_session(
+    base_url: str, user_id: str, command_id: int, timeout: float = DEFAULT_TIMEOUT
+) -> int:
     """Create a new session starting from a previous command.
 
     Parameters
@@ -62,20 +73,27 @@ def fork_session(base_url: str, user_id: str, command_id: int, timeout: float = 
 
     Returns
     -------
-    None
+    int
+        Status code, ``0`` on success, non-zero on failure.
     """
 
-    resp = requests.post(
-        f"{base_url}/rpc/fork_session",
-        json={"user_id": user_id, "source_command_id": command_id},
-        timeout=timeout,
-    )
-    resp.raise_for_status()
+    try:
+        resp = requests.post(
+            f"{base_url}/rpc/fork_session",
+            json={"user_id": user_id, "source_command_id": command_id},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        print(f"fork failed: {exc}", file=sys.stderr)
+        return 1
+
     data = resp.json()
     print(data)
+    return 0
 
 
-def replay_session(base_url: str, session: str, timeout: float = DEFAULT_TIMEOUT) -> None:
+def replay_session(base_url: str, session: str, timeout: float = DEFAULT_TIMEOUT) -> int:
     """Request a replay of a past session.
 
     Parameters
@@ -89,17 +107,24 @@ def replay_session(base_url: str, session: str, timeout: float = DEFAULT_TIMEOUT
 
     Returns
     -------
-    None
+    int
+        Status code, ``0`` on success, non-zero on failure.
     """
 
-    resp = requests.post(
-        f"{base_url}/rpc/replay_session",
-        json={"session": session},
-        timeout=timeout,
-    )
-    resp.raise_for_status()
+    try:
+        resp = requests.post(
+            f"{base_url}/rpc/replay_session",
+            json={"session": session},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        print(f"replay failed: {exc}", file=sys.stderr)
+        return 1
+
     data = resp.json()
     print(data)
+    return 0
 
 
 def tail_output(
@@ -108,16 +133,27 @@ def tail_output(
     interval: float = 1.0,
     since: int | None = None,
     timeout: float = DEFAULT_TIMEOUT,
-) -> None:
-    """Poll for new output and print it continuously."""
+) -> int:
+    """Poll for new output and print it continuously.
+
+    Returns
+    -------
+    int
+        Status code, ``0`` on success, non-zero on failure.
+    """
     last_id: Any = since
     try:
         while True:
             params = {"user_id": f"eq.{user_id}"}
-            resp = requests.get(
-                f"{base_url}/rpc/latest_output", params=params, timeout=timeout
-            )
-            resp.raise_for_status()
+            try:
+                resp = requests.get(
+                    f"{base_url}/rpc/latest_output", params=params, timeout=timeout
+                )
+                resp.raise_for_status()
+            except requests.RequestException as exc:  # pragma: no cover - network failure
+                print(f"tail failed: {exc}", file=sys.stderr)
+                return 1
+
             rows = resp.json()
             for row in rows:
                 if last_id is None or row["id"] > last_id:
@@ -128,7 +164,9 @@ def tail_output(
                     last_id = row["id"]
             time.sleep(interval)
     except KeyboardInterrupt:
-        pass
+        return 0
+
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -178,18 +216,20 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "exec":
-        exec_command(args.base_url, args.user, args.cmd, args.timeout)
+        rc = exec_command(args.base_url, args.user, args.cmd, args.timeout)
     elif args.command == "replay":
-        replay_session(args.base_url, args.session, args.timeout)
+        rc = replay_session(args.base_url, args.session, args.timeout)
     elif args.command == "fork":
-        fork_session(args.base_url, args.user, args.at, args.timeout)
+        rc = fork_session(args.base_url, args.user, args.at, args.timeout)
     elif args.command == "tail":
-        tail_output(args.base_url, args.user, args.interval, args.since, args.timeout)
+        rc = tail_output(
+            args.base_url, args.user, args.interval, args.since, args.timeout
+        )
     else:
         parser.print_help()
         return 1
 
-    return 0
+    return rc
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Return status codes from exec, fork, replay, and tail commands
- Gracefully handle HTTP request failures with helpful stderr messages
- Main entry point now propagates subcommand exit codes

## Testing
- `pytest -q` *(fails: psycopg2.OperationalError: connection to server on socket ...)*

------
https://chatgpt.com/codex/tasks/task_e_689d277d5ec4832897de633ef9d048d1