### PR TITLE
Remove unused import from cleanup tests

### DIFF
--- a/tests/test_cleanup_agent.py
+++ b/tests/test_cleanup_agent.py
@@ -6,7 +6,6 @@ import psycopg2
 import pytest
 
 from workers.cleanup_agent import cleanup_once
-from workers.db import get_conn
 
 
 INIT_SQL = Path("sql/init_schema.sql").read_text()


### PR DESCRIPTION
## Summary
- remove unused `get_conn` import from cleanup test

## Testing
- `pytest -k cleanup_agent` (skipped: TEST_DATABASE_URL not set)


------
https://chatgpt.com/codex/tasks/task_e_689f4c3e89608328912eb37396fc0c64