### PR TITLE
Use new parameter names for tail output

### DIFF
--- a/cli/shell_cli.py
+++ b/cli/shell_cli.py
@@ -144,10 +144,10 @@ def tail_output(
     last_id: Any = since
     try:
         while True:
-            params = {"user_id": f"eq.{user_id}"}
+            params = {"p_user_id": f"eq.{user_id}"}
 
             if last_id is not None:
-                params["since_id"] = last_id
+                params["p_since_id"] = last_id
 
             try:
                 resp = requests.get(


### PR DESCRIPTION
## Summary
- update CLI tail command to use PostgREST `p_user_id` and `p_since_id` parameters

## Testing
- `pytest -q`
- `python cli/shell_cli.py --base-url http://localhost:8000 tail --user 123 --interval 0.2` (with stub PostgREST server)


------
https://chatgpt.com/codex/tasks/task_e_689f4c3bd37883289509434e46ec2cb2