### PR TITLE
Use context manager for monitor agent CSV output

### DIFF
--- a/workers/monitor_agent.py
+++ b/workers/monitor_agent.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 """pg_shell monitor agent.
 
 Collects usage statistics from the ``commands`` table. Metrics include
@@ -59,28 +61,27 @@ def main() -> None:
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
-    csv_writer = None
-    csv_file = None
+    def run_loop(csv_writer: csv.writer | None) -> None:
+        while True:
+            conn = get_conn()
+            try:
+                rows = collect_metrics(conn)
+                output_metrics(rows, csv_writer)
+            finally:
+                conn.close()
+
+            if args.once:
+                break
+            time.sleep(args.interval)
+
     if args.csv:
-        csv_file = open(args.csv, "a", newline="")
-        csv_writer = csv.writer(csv_file)
-        if csv_file.tell() == 0:
-            csv_writer.writerow(["user_id", "day", "command_count", "avg_seconds"])
-
-    while True:
-        conn = get_conn()
-        try:
-            rows = collect_metrics(conn)
-            output_metrics(rows, csv_writer)
-        finally:
-            conn.close()
-
-        if args.once:
-            break
-        time.sleep(args.interval)
-
-    if csv_file:
-        csv_file.close()
+        with open(args.csv, "a", newline="") as csv_file:
+            csv_writer = csv.writer(csv_file)
+            if csv_file.tell() == 0:
+                csv_writer.writerow(["user_id", "day", "command_count", "avg_seconds"])
+            run_loop(csv_writer)
+    else:
+        run_loop(None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- wrap CSV handling in a context manager for automatic cleanup
- centralize monitoring loop in `run_loop` function
- postpone type hint evaluation with `from __future__ import annotations`

## Testing
- `pytest`
- `PG_CONN='postgresql://postgres:postgres@localhost:5432/postgres' PYTHONPATH=. python workers/monitor_agent.py --csv /tmp/metrics.csv --once` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c3e1a9483288c4b04c11cae0905