### PR TITLE
Raise runtime error on DB connection failure

### DIFF
--- a/workers/cleanup_agent.py
+++ b/workers/cleanup_agent.py
@@ -62,7 +62,11 @@ def main():
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
     while True:
-        conn = get_conn()
+        try:
+            conn = get_conn()
+        except RuntimeError as exc:
+            logging.error("Cleanup agent failed to connect to database: %s", exc)
+            break
         try:
             cleanup_once(conn, args.days)
         finally:

--- a/workers/db.py
+++ b/workers/db.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 
 import psycopg2
 
@@ -9,10 +8,11 @@ def get_conn():
     """Return a PostgreSQL connection using DATABASE_URL or PG_CONN env vars."""
     dsn = os.environ.get("DATABASE_URL") or os.environ.get("PG_CONN")
     if not dsn:
-        logging.error("DATABASE_URL or PG_CONN environment variable required")
-        sys.exit(1)
+        msg = "DATABASE_URL or PG_CONN environment variable required"
+        logging.error(msg)
+        raise RuntimeError(msg)
     try:
         return psycopg2.connect(dsn)
-    except Exception:
+    except Exception as exc:
         logging.exception("Failed to connect to database")
-        sys.exit(1)
+        raise RuntimeError("Failed to connect to database") from exc

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -168,7 +168,11 @@ def handle_command(conn, row: Dict[str, Any]) -> None:
 def main() -> None:
     level = getattr(logging, LOG_LEVEL, logging.INFO)
     logging.basicConfig(level=level, format="%(asctime)s %(message)s")
-    conn = get_conn()
+    try:
+        conn = get_conn()
+    except RuntimeError as exc:
+        logging.error("Executor agent failed to connect to database: %s", exc)
+        return
     setup_listener(conn)
     while True:
         row = fetch_pending(conn)

--- a/workers/monitor_agent.py
+++ b/workers/monitor_agent.py
@@ -68,7 +68,11 @@ def main() -> None:
             csv_writer.writerow(["user_id", "day", "command_count", "avg_seconds"])
 
     while True:
-        conn = get_conn()
+        try:
+            conn = get_conn()
+        except RuntimeError as exc:
+            logging.error("Monitor agent failed to connect to database: %s", exc)
+            break
         try:
             rows = collect_metrics(conn)
             output_metrics(rows, csv_writer)

--- a/workers/replay_agent.py
+++ b/workers/replay_agent.py
@@ -39,7 +39,10 @@ def main() -> None:
     )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
-    replay_commands(args.user, args.start)
+    try:
+        replay_commands(args.user, args.start)
+    except RuntimeError as exc:
+        logging.error("Replay agent failed to connect to database: %s", exc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace `sys.exit` calls in `get_conn` with `RuntimeError` to avoid process termination
- Guard agent scripts against new connection errors so they log and exit cleanly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4c3d4dd0832888ece50327857d25