### PR TITLE
Add max polls option to CLI tail command

### DIFF
--- a/tests/test_shell_cli.py
+++ b/tests/test_shell_cli.py
@@ -1,0 +1,21 @@
+import cli.shell_cli as sc
+
+def test_tail_output_stops_after_max_polls(monkeypatch):
+    calls = []
+
+    class Resp:
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return []
+
+    def fake_get(*args, **kwargs):
+        calls.append(1)
+        return Resp()
+
+    monkeypatch.setattr(sc.requests, 'get', fake_get)
+    monkeypatch.setattr(sc.time, 'sleep', lambda _: None)
+
+    rc = sc.tail_output('http://example', 'u1', interval=0, max_polls=2)
+    assert rc == 0
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- add `max_polls` limit to `tail_output` and expose via CLI
- test that tail loop exits after requested number of polls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0cefb3c08328801c86df6a5a09e7