### PR TITLE
Stream monitor metrics

### DIFF
--- a/tests/test_monitor_agent.py
+++ b/tests/test_monitor_agent.py
@@ -1,0 +1,67 @@
+import workers.monitor_agent as monitor_agent
+
+
+def test_collect_metrics_streams(monkeypatch):
+    rows = [
+        ("u1", "2024-01-01", 1, 0.5),
+        ("u2", "2024-01-01", 2, 1.0),
+        ("u1", "2024-01-02", 3, 1.5),
+    ]
+    fetch_calls = []
+
+    class FakeCursor:
+        def __init__(self):
+            self.idx = 0
+
+        def execute(self, sql):
+            pass
+
+        def fetchone(self):
+            fetch_calls.append(self.idx)
+            if self.idx >= len(rows):
+                return None
+            row = rows[self.idx]
+            self.idx += 1
+            return row
+
+        def fetchall(self):  # pragma: no cover - should not run
+            raise AssertionError("fetchall should not be called")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    cursor = FakeCursor()
+
+    class FakeConn:
+        def cursor(self, name=None):
+            # ensure server-side cursor is requested
+            assert name is not None
+            return cursor
+
+    conn = FakeConn()
+
+    gen = monitor_agent.collect_metrics(conn)
+    # consume one row to ensure generator yields incrementally
+    first = next(gen)
+    assert first == rows[0]
+    assert fetch_calls == [0]
+
+    captured = []
+
+    def fake_print(line):
+        captured.append(line)
+
+    monkeypatch.setattr("builtins.print", fake_print)
+
+    # process remaining rows
+    monitor_agent.output_metrics(gen, None)
+
+    # fetchone called for remaining rows plus final sentinel None
+    assert fetch_calls == [0, 1, 2, 3]
+    # only remaining two rows printed
+    assert len(captured) == 2
+    assert "u2" in captured[0]
+    assert "u1" in captured[1]

--- a/workers/monitor_agent.py
+++ b/workers/monitor_agent.py
@@ -13,7 +13,7 @@ import argparse
 import csv
 import logging
 import time
-from typing import Iterable, Tuple
+from typing import Iterator, Tuple
 
 from workers.db import get_conn
 
@@ -21,8 +21,9 @@ from workers.db import get_conn
 Row = Tuple[str, str, int, float]
 
 
-def collect_metrics(conn) -> Iterable[Row]:
-    with conn.cursor() as cur:
+def collect_metrics(conn) -> Iterator[Row]:
+    """Yield metric rows one by one using a server-side cursor."""
+    with conn.cursor(name="monitor_agent_metrics") as cur:
         cur.execute(
             """
             SELECT user_id,
@@ -35,10 +36,11 @@ def collect_metrics(conn) -> Iterable[Row]:
           ORDER BY day, user_id
             """
         )
-        return cur.fetchall()
+        for row in iter(cur.fetchone, None):
+            yield row
 
 
-def output_metrics(rows: Iterable[Row], csv_writer: csv.writer | None) -> None:
+def output_metrics(rows: Iterator[Row], csv_writer: csv.writer | None) -> None:
     for row in rows:
         user_id, day, count, avg_seconds = row
         avg_seconds = round(avg_seconds or 0.0, 3)
@@ -65,8 +67,7 @@ def main() -> None:
         while True:
             conn = get_conn()
             try:
-                rows = collect_metrics(conn)
-                output_metrics(rows, csv_writer)
+                output_metrics(collect_metrics(conn), csv_writer)
             finally:
                 conn.close()
 


### PR DESCRIPTION
## Summary
- Stream monitor metrics using a server-side cursor to avoid loading entire result sets
- Allow metric output to consume iterators directly
- Test that metrics are processed row-by-row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af0ceda3ac8328b77e65b08247e9dc