### PR TITLE
Gracefully handle monitor agent connection failures

### DIFF
--- a/tests/test_monitor_agent.py
+++ b/tests/test_monitor_agent.py
@@ -1,0 +1,21 @@
+import logging
+import sys
+
+import pytest
+
+import workers.monitor_agent as monitor_agent
+
+
+def test_main_handles_connection_error(monkeypatch, caplog):
+    def fake_get_conn():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(monitor_agent, "get_conn", fake_get_conn)
+    monkeypatch.setattr(sys, "argv", ["monitor_agent", "--once"])
+
+    with caplog.at_level(logging.ERROR):
+        code = monitor_agent.main()
+
+    assert code == 1
+    assert "boom" in caplog.text
+


### PR DESCRIPTION
## Summary
- Guard monitor agent's run loop against `RuntimeError` from `get_conn`
- Return exit codes and log errors when database connection fails
- Add regression test for connection failure handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0cec9c7c8328bfde5be0675af895