### PR TITLE
Handle malformed commands in executor_agent

### DIFF
--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -144,6 +144,39 @@ def test_handle_command_cd_with_extra_args_runs_subprocess(monkeypatch):
     assert captured['exit_code'] == 0
 
 
+def test_handle_command_malformed_command(monkeypatch):
+    captured: dict = {}
+
+    def fake_update_command(conn, cmd_id, status, output, exit_code):
+        captured['status'] = status
+        captured['output'] = output
+        captured['exit_code'] = exit_code
+
+    def fake_run_subprocess(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError('run_subprocess should not be called')
+
+    def fake_update_cwd(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError('update_cwd should not be called')
+
+    monkeypatch.setattr('workers.executor_agent.update_command', fake_update_command)
+    monkeypatch.setattr('workers.executor_agent.run_subprocess', fake_run_subprocess)
+    monkeypatch.setattr('workers.executor_agent.update_cwd', fake_update_cwd)
+
+    row = {
+        'id': 4,
+        'user_id': 'u1',
+        'command': 'echo "unterminated',
+        'cwd_snapshot': '.',
+        'env_snapshot': None,
+    }
+
+    handle_command(None, row)
+
+    assert captured['status'] == 'failed'
+    assert captured['exit_code'] == 1
+    assert 'No closing quotation' in captured['output']
+
+
 def test_main_closes_connection_on_keyboard_interrupt(monkeypatch):
     closed = False
 

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -115,8 +115,18 @@ def handle_command(conn, row: Dict[str, Any]) -> None:
         row["user_id"],
         command,
     )
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        logging.error(
+            "Command %s for user %s failed: %s",
+            row["id"],
+            row["user_id"],
+            exc,
+        )
+        update_command(conn, row["id"], "failed", str(exc), 1)
+        return
 
-    tokens = shlex.split(command)
     if len(tokens) == 2 and tokens[0] == "cd":
         path = tokens[1]
         if os.path.isabs(path):


### PR DESCRIPTION
## Summary
- Ensure executor_agent gracefully handles malformed command strings
- Add unit test for malformed command handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0cea22b48328bc6835ac2ab0b77d