### PR TITLE
Add indexes for commands table and verify planner usage

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -33,7 +33,13 @@ CREATE TABLE commands (
   env_snapshot JSONB,
   CONSTRAINT status_enum CHECK (status IN ('pending','running','done','failed'))
 );
+
+CREATE INDEX commands_status_submitted_at_idx ON commands (status, submitted_at);
+CREATE INDEX commands_user_id_id_idx ON commands (user_id, id);
 ```
+
+- `commands_status_submitted_at_idx` keeps executor polling queries (`WHERE status='pending' ORDER BY submitted_at`) using an index-only scan.
+- `commands_user_id_id_idx` accelerates user-specific history queries (e.g., fetch latest command id) without scanning unrelated rows.
 
 ---
 

--- a/sql/init_schema.sql
+++ b/sql/init_schema.sql
@@ -26,3 +26,9 @@ CREATE TABLE IF NOT EXISTS commands (
   completed_at TIMESTAMP,
   CONSTRAINT status_enum CHECK (status IN ('pending','running','done','failed'))
 );
+
+CREATE INDEX IF NOT EXISTS commands_status_submitted_at_idx
+  ON commands (status, submitted_at);
+
+CREATE INDEX IF NOT EXISTS commands_user_id_id_idx
+  ON commands (user_id, id);

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -3,3 +3,7 @@
 \i sql/submit_command.sql
 \i sql/latest_output.sql -- updated latest_output with optional since_id filter
 \i sql/fork_session.sql
+
+-- Ensure supporting indexes exist on commands for executor and query performance
+CREATE INDEX IF NOT EXISTS commands_status_submitted_at_idx ON commands (status, submitted_at);
+CREATE INDEX IF NOT EXISTS commands_user_id_id_idx ON commands (user_id, id);

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,3 +1,4 @@
+import json
 import os
 import uuid
 from pathlib import Path
@@ -9,6 +10,29 @@ INIT_SQL = Path('sql/init_schema.sql').read_text()
 SUBMIT_SQL = Path('sql/submit_command.sql').read_text()
 LATEST_SQL = Path('sql/latest_output.sql').read_text()
 FORK_SQL = Path('sql/fork_session.sql').read_text()
+
+
+def _collect_index_names(plan_node):
+    indexes = []
+
+    def _traverse(node):
+        index_name = node.get("Index Name")
+        if index_name:
+            indexes.append(index_name)
+        for child in node.get("Plans", []):
+            _traverse(child)
+
+    _traverse(plan_node)
+    return indexes
+
+
+def _fetch_plan_root(cur):
+    raw = cur.fetchone()[0]
+    if isinstance(raw, str):
+        raw = json.loads(raw)
+    if isinstance(raw, list):
+        raw = raw[0]
+    return raw["Plan"]
 
 
 @pytest.fixture(scope="module")
@@ -84,3 +108,42 @@ def test_latest_output_since_id(conn):
         rows = cur.fetchall()
         assert len(rows) == 1
         assert rows[0][0] == ids[2]
+
+
+def test_command_indexes_query_plans(conn):
+    primary_user = str(uuid.uuid4())
+    secondary_user = str(uuid.uuid4())
+    with conn.cursor() as cur:
+        cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (primary_user, "planner"))
+        cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (secondary_user, "other"))
+
+        # Populate enough data to give the planner a strong preference for the new indexes
+        for i in range(50):
+            cur.execute(
+                "INSERT INTO commands(user_id, command, status, submitted_at)"
+                " VALUES (%s, %s, %s, now() - (%s * INTERVAL '1 minute'))",
+                (primary_user, f'cmd {i}', 'pending' if i % 3 else 'done', i),
+            )
+        for i in range(10):
+            cur.execute(
+                "INSERT INTO commands(user_id, command, status, submitted_at)"
+                " VALUES (%s, %s, %s, now() - (%s * INTERVAL '1 minute'))",
+                (secondary_user, f'spare {i}', 'pending', i),
+            )
+
+        cur.execute(
+            "EXPLAIN (FORMAT JSON) "
+            "SELECT id FROM commands WHERE status = 'pending' ORDER BY submitted_at LIMIT 5"
+        )
+        pending_plan = _fetch_plan_root(cur)
+        pending_indexes = _collect_index_names(pending_plan)
+        assert "commands_status_submitted_at_idx" in pending_indexes
+
+        cur.execute(
+            "EXPLAIN (FORMAT JSON) "
+            "SELECT id FROM commands WHERE user_id = %s ORDER BY id DESC LIMIT 1",
+            (primary_user,),
+        )
+        latest_plan = _fetch_plan_root(cur)
+        latest_indexes = _collect_index_names(latest_plan)
+        assert "commands_user_id_id_idx" in latest_indexes


### PR DESCRIPTION
## Summary
- add multicolumn indexes on commands for status ordering and user history lookups
- ensure install script creates the new indexes for fresh deployments
- document the indexes in the spec and add a planner-focused test that checks EXPLAIN output

## Testing
- pytest tests/test_functions.py::test_command_indexes_query_plans *(skipped: TEST_DATABASE_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e9bc8b948328bc551fc8cb4b93de