### PR TITLE
Improve monitor agent reconnection logic

### DIFF
--- a/workers/monitor_agent.py
+++ b/workers/monitor_agent.py
@@ -66,6 +66,15 @@ def main() -> None:
     def run_loop(csv_writer: csv.writer | None) -> int:
         while True:
             try:
+                conn = get_conn()
+            except RuntimeError as exc:
+                logging.error("Failed to connect to database: %s", exc)
+                if args.once:
+                    return 1
+                time.sleep(min(args.interval, 5))
+                continue
+
+            try:
                 output_metrics(collect_metrics(conn), csv_writer)
             finally:
                 conn.close()


### PR DESCRIPTION
## Summary
- obtain a new database connection at the start of each metrics loop iteration and log connection errors before retrying
- ensure database connections are closed after processing metrics, even when collection raises
- keep retrying after connection failures unless the agent was launched with --once

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e9b9d5408328a4eeca407577e4e9