### PR TITLE
Validate submit_command user existence before inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,14 @@ pip install -r requirements.txt
 pytest
 ```
 
+## User Provisioning Contract
+
+`submit_command(p_user_id UUID, p_command TEXT)` requires that `p_user_id` already
+exists in the `users` table. The function validates this up front and raises a
+clear SQL error (`22023`) for unknown users instead of relying on downstream
+foreign-key failures.
+
 
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
-

--- a/SPEC.md
+++ b/SPEC.md
@@ -48,6 +48,7 @@ CREATE INDEX commands_user_id_id_idx ON commands (user_id, id);
 ### `submit_command(user_id UUID, command TEXT) RETURNS INTEGER`
 
 - Inserts a new `commands` row with snapshots from `environments`
+- Requires `user_id` to already exist in `users`; raises SQLSTATE `22023` with a user-friendly error for unknown users
 - Returns `commands.id`
 
 ### `latest_output(user_id UUID) RETURNS TABLE(id, command, output, exit_code, status, submitted_at)`

--- a/sql/submit_command.sql
+++ b/sql/submit_command.sql
@@ -4,10 +4,18 @@
 CREATE OR REPLACE FUNCTION submit_command(p_user_id UUID, p_command TEXT)
 RETURNS INTEGER LANGUAGE plpgsql AS $$
 DECLARE
+  user_exists INTEGER;
   env_row environments%ROWTYPE;
   new_id INTEGER;
   channel TEXT;
 BEGIN
+  -- validate user exists before creating dependent records
+  SELECT 1 INTO user_exists FROM users WHERE id = p_user_id;
+  IF user_exists IS NULL THEN
+    RAISE EXCEPTION 'Unknown user_id: %. Create the user before submitting commands.', p_user_id
+      USING ERRCODE = '22023';
+  END IF;
+
   -- ensure environment row exists
   SELECT * INTO env_row FROM environments WHERE user_id = p_user_id;
   IF NOT FOUND THEN

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -152,6 +152,16 @@ def test_submit_command_respects_configured_channel(conn):
     assert notification.payload == str(cmd_id)
 
 
+def test_submit_command_requires_existing_user(conn):
+    missing_user_id = str(uuid.uuid4())
+    with conn.cursor() as cur:
+        with pytest.raises(psycopg2.Error) as exc_info:
+            cur.execute("SELECT submit_command(%s, %s)", (missing_user_id, "echo nope"))
+    err = exc_info.value
+    assert "Unknown user_id" in str(err)
+    assert err.pgcode == '22023'
+
+
 def test_fork_session(conn):
     user_id = str(uuid.uuid4())
     with conn.cursor() as cur:


### PR DESCRIPTION
### Motivation
- Prevent inserting dependent rows for unknown users by failing fast with a clear SQL error when `submit_command` is called with a nonexistent `p_user_id`.
- Make the API contract deterministic so callers know whether they must pre-create users or expect auto-provisioning.

### Description
- Add an explicit `SELECT 1 FROM users WHERE id = p_user_id` at the start of `submit_command(p_user_id UUID, p_command TEXT)` and raise `RAISE EXCEPTION ... USING ERRCODE = '22023'` when no row is found in `users` (file `sql/submit_command.sql`).
- Keep existing behavior for environments and command insertion intact by validating before creating `environments` or `commands` rows.
- Add an integration test `test_submit_command_requires_existing_user` asserting the error message and `pgcode == '22023'` (file `tests/test_functions.py`).
- Update `README.md` and `SPEC.md` to document the user provisioning contract and the deterministic error behavior for unknown users.

### Testing
- Ran `pytest tests/test_functions.py -q` locally; tests were executed but skipped in this environment because `TEST_DATABASE_URL` was not provided (7 tests skipped). 
- The added test `test_submit_command_requires_existing_user` is included in the test suite and asserts both error text and SQLSTATE `22023` when exercised against a real test database.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1797d97b08328bf994f5efa0cf91c)