### PR TITLE
Scope fork_session source command lookup to caller user

### DIFF
--- a/sql/fork_session.sql
+++ b/sql/fork_session.sql
@@ -9,9 +9,10 @@ BEGIN
   SELECT cwd_snapshot, env_snapshot
     INTO src
     FROM commands
-    WHERE id = p_source_command_id;
+    WHERE id = p_source_command_id
+      AND user_id = p_user_id;
   IF NOT FOUND THEN
-    RAISE EXCEPTION 'source command % not found', p_source_command_id;
+    RAISE EXCEPTION 'source command not found or forbidden';
   END IF;
 
   INSERT INTO environments(user_id, cwd, env)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -152,7 +152,7 @@ def test_submit_command_respects_configured_channel(conn):
     assert notification.payload == str(cmd_id)
 
 
-def test_fork_session(conn):
+def test_fork_session_same_user_source_command_succeeds(conn):
     user_id = str(uuid.uuid4())
     with conn.cursor() as cur:
         cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (user_id, "u2"))
@@ -171,6 +171,29 @@ def test_fork_session(conn):
         cur.execute("SELECT cwd FROM environments WHERE user_id=%s", (user_id,))
         cwd = cur.fetchone()[0]
         assert cwd == '/home/start'
+
+
+def test_fork_session_different_user_source_command_fails(conn):
+    source_user_id = str(uuid.uuid4())
+    target_user_id = str(uuid.uuid4())
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users(id, username) VALUES (%s, %s)",
+            (source_user_id, "fork-src"),
+        )
+        cur.execute(
+            "INSERT INTO users(id, username) VALUES (%s, %s)",
+            (target_user_id, "fork-dst"),
+        )
+        cur.execute("SELECT submit_command(%s, %s)", (source_user_id, "pwd"))
+        source_cmd_id = cur.fetchone()[0]
+        cur.execute(
+            "UPDATE commands SET cwd_snapshot=%s, env_snapshot=%s::jsonb WHERE id=%s",
+            ('/home/source', '{"SRC":"1"}', source_cmd_id),
+        )
+
+        with pytest.raises(psycopg2.errors.RaiseException, match="not found or forbidden"):
+            cur.execute("SELECT fork_session(%s, %s)", (target_user_id, source_cmd_id))
 
 
 def test_latest_output_since_id(conn):


### PR DESCRIPTION
### Motivation
- Prevent forks from using command snapshots that belong to a different user by scoping the source lookup to the requesting user to avoid accidental or malicious cross-user state leakage.
- Provide a generic not-found/forbidden error to avoid leaking information about the existence of a command id owned by another user.

### Description
- Updated `fork_session(p_user_id UUID, p_source_command_id INTEGER)` to select `cwd_snapshot` and `env_snapshot` only when `id = p_source_command_id AND user_id = p_user_id` in `sql/fork_session.sql`.
- Replaced the previous command-specific error with a generic `RAISE EXCEPTION 'source command not found or forbidden'` when no matching row is found.
- Added/renamed tests in `tests/test_functions.py` to cover the same-user success path (`test_fork_session_same_user_source_command_succeeds`) and a cross-user failure path (`test_fork_session_different_user_source_command_fails`) that asserts the generic exception is raised.
- Reviewed repository SQL/spec files for PostgREST/RLS/policy artifacts and found no role/policy objects to update, so no policy changes were made.

### Testing
- Ran the fork-session-focused test selection with `pytest -q tests/test_functions.py -k fork_session` in the CI/dev environment used for this change.
- Tests were skipped in this run because the `TEST_DATABASE_URL` environment variable was not set, so no database-backed assertions ran in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1797feb888328a43765dc03ad698a)