### PR TITLE
Enforce SHELL_ROOT boundary for cd in executor_agent

### DIFF
--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -59,7 +59,7 @@ def test_handle_command_uses_combined_output(monkeypatch):
     assert captured['cmd_id'] == 42
 
 
-def test_handle_command_cd_changes_directory(tmp_path, monkeypatch):
+def test_handle_command_cd_relative_within_root_succeeds(tmp_path, monkeypatch):
     captured: dict = {}
 
     def fake_update_cwd(conn, user_id, cwd):
@@ -77,12 +77,14 @@ def test_handle_command_cd_changes_directory(tmp_path, monkeypatch):
     monkeypatch.setattr('workers.executor_agent.update_command', fake_update_command)
     monkeypatch.setattr('workers.executor_agent.run_subprocess', fake_run_subprocess)
 
+    monkeypatch.setenv('SHELL_ROOT', str(tmp_path))
+
     subdir = tmp_path / 'sub'
     subdir.mkdir()
     row = {
         'id': 1,
         'user_id': 'u1',
-        'command': f'cd {subdir}',
+        'command': 'cd sub',
         'cwd_snapshot': str(tmp_path),
         'env_snapshot': None,
     }
@@ -113,6 +115,8 @@ def test_handle_command_cd_nonexistent_path(tmp_path, monkeypatch):
     monkeypatch.setattr('workers.executor_agent.update_command', fake_update_command)
     monkeypatch.setattr('workers.executor_agent.run_subprocess', fake_run_subprocess)
 
+    monkeypatch.setenv('SHELL_ROOT', str(tmp_path))
+
     row = {
         'id': 2,
         'user_id': 'u1',
@@ -126,6 +130,74 @@ def test_handle_command_cd_nonexistent_path(tmp_path, monkeypatch):
     assert captured['status'] == 'failed'
     assert captured['exit_code'] == 1
     assert 'No such file or directory' in captured['output']
+
+
+def test_handle_command_cd_dotdot_escaping_root_fails(tmp_path, monkeypatch):
+    captured: dict = {}
+
+    def fake_update_cwd(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError('update_cwd should not be called')
+
+    def fake_update_command(conn, cmd_id, status, output, exit_code):
+        captured['status'] = status
+        captured['output'] = output
+        captured['exit_code'] = exit_code
+
+    def fake_run_subprocess(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError('run_subprocess should not be called')
+
+    monkeypatch.setenv('SHELL_ROOT', str(tmp_path))
+    monkeypatch.setattr('workers.executor_agent.update_cwd', fake_update_cwd)
+    monkeypatch.setattr('workers.executor_agent.update_command', fake_update_command)
+    monkeypatch.setattr('workers.executor_agent.run_subprocess', fake_run_subprocess)
+
+    row = {
+        'id': 5,
+        'user_id': 'u1',
+        'command': 'cd ..',
+        'cwd_snapshot': str(tmp_path),
+        'env_snapshot': None,
+    }
+
+    handle_command(None, row)
+
+    assert captured['status'] == 'failed'
+    assert captured['exit_code'] == 1
+    assert 'Permission denied' in captured['output']
+
+
+def test_handle_command_cd_absolute_outside_root_fails(tmp_path, monkeypatch):
+    captured: dict = {}
+
+    def fake_update_cwd(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError('update_cwd should not be called')
+
+    def fake_update_command(conn, cmd_id, status, output, exit_code):
+        captured['status'] = status
+        captured['output'] = output
+        captured['exit_code'] = exit_code
+
+    def fake_run_subprocess(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError('run_subprocess should not be called')
+
+    monkeypatch.setenv('SHELL_ROOT', str(tmp_path))
+    monkeypatch.setattr('workers.executor_agent.update_cwd', fake_update_cwd)
+    monkeypatch.setattr('workers.executor_agent.update_command', fake_update_command)
+    monkeypatch.setattr('workers.executor_agent.run_subprocess', fake_run_subprocess)
+
+    row = {
+        'id': 6,
+        'user_id': 'u1',
+        'command': 'cd /tmp',
+        'cwd_snapshot': str(tmp_path),
+        'env_snapshot': None,
+    }
+
+    handle_command(None, row)
+
+    assert captured['status'] == 'failed'
+    assert captured['exit_code'] == 1
+    assert 'Permission denied' in captured['output']
 
 
 def test_handle_command_cd_with_extra_args_runs_subprocess(monkeypatch):

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -211,10 +211,26 @@ def handle_command(conn, row: Dict[str, Any]) -> None:
 
     if len(tokens) == 2 and tokens[0] == "cd":
         path = tokens[1]
+        shell_root = os.path.realpath(os.getenv("SHELL_ROOT", "/home/sandbox"))
         if os.path.isabs(path):
-            new_cwd = os.path.normpath(path)
+            new_cwd = os.path.realpath(path)
         else:
-            new_cwd = os.path.normpath(os.path.join(row["cwd_snapshot"], path))
+            new_cwd = os.path.realpath(os.path.join(row["cwd_snapshot"], path))
+        try:
+            in_root = os.path.commonpath([shell_root, new_cwd]) == shell_root
+        except ValueError:
+            in_root = False
+        if not in_root:
+            error = f"cd: {path}: Permission denied"
+            update_command(conn, row["id"], "failed", error, 1)
+            logging.error(
+                "Command %s for user %s failed: path %s escapes shell root %s",
+                row["id"],
+                row["user_id"],
+                new_cwd,
+                shell_root,
+            )
+            return
         if not os.path.isdir(new_cwd):
             error = f"cd: {path}: No such file or directory"
             update_command(conn, row["id"], "failed", error, 1)


### PR DESCRIPTION
### Motivation
- Prevent `cd` commands from escaping a configured filesystem root to limit access and reduce attack surface for the executor agent.

### Description
- Add a `SHELL_ROOT` environment variable (default `/home/sandbox`) and resolve it with `os.path.realpath` in `handle_command()`.
- Resolve requested `cd` targets with `os.path.realpath` and verify containment using `os.path.commonpath`, handling `ValueError` if paths are incompatible.
- Reject escapes with a shell-like error `cd: <path>: Permission denied` and return without calling `update_cwd`, and log the event; normal `No such file or directory` handling is preserved.
- Extend `tests/test_executor_agent.py` to cover: a relative `cd` inside the root succeeds, `cd ..` that would escape the root fails, and an absolute path outside the root fails, and adapt the existing relative `cd` test to set `SHELL_ROOT`.

### Testing
- Ran `pytest -q tests/test_executor_agent.py` and all tests passed (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17980dd2883289aebef6548793df0)