### PR TITLE
Improve replay agent idempotency and batching

### DIFF
--- a/sql/init_schema.sql
+++ b/sql/init_schema.sql
@@ -17,6 +17,8 @@ CREATE TABLE IF NOT EXISTS commands (
   id SERIAL PRIMARY KEY,
   user_id UUID NOT NULL REFERENCES users(id),
   command TEXT NOT NULL,
+  replay_of_command_id INT REFERENCES commands(id),
+  replay_run_id UUID,
   submitted_at TIMESTAMP NOT NULL DEFAULT now(),
   status TEXT NOT NULL DEFAULT 'pending',
   output TEXT,
@@ -42,3 +44,6 @@ CREATE INDEX IF NOT EXISTS commands_status_submitted_at_idx
 CREATE INDEX IF NOT EXISTS commands_user_id_id_idx
   ON commands (user_id, id);
 
+CREATE INDEX IF NOT EXISTS commands_user_replay_source_idx
+  ON commands (user_id, replay_of_command_id)
+  WHERE replay_of_command_id IS NOT NULL;

--- a/sql/submit_command.sql
+++ b/sql/submit_command.sql
@@ -1,7 +1,12 @@
 -- submit_command: queues a command for execution
 -- References SPEC.md (RPC function) and executor_agent in AGENTS.md
 
-CREATE OR REPLACE FUNCTION submit_command(p_user_id UUID, p_command TEXT)
+CREATE OR REPLACE FUNCTION submit_command(
+  p_user_id UUID,
+  p_command TEXT,
+  p_replay_of_command_id INT DEFAULT NULL,
+  p_replay_run_id UUID DEFAULT NULL
+)
 RETURNS INTEGER LANGUAGE plpgsql AS $$
 DECLARE
   env_row environments%ROWTYPE;
@@ -15,8 +20,22 @@ BEGIN
       RETURNING * INTO env_row;
   END IF;
 
-  INSERT INTO commands(user_id, command, cwd_snapshot, env_snapshot)
-    VALUES (p_user_id, p_command, env_row.cwd, env_row.env)
+  INSERT INTO commands(
+    user_id,
+    command,
+    cwd_snapshot,
+    env_snapshot,
+    replay_of_command_id,
+    replay_run_id
+  )
+    VALUES (
+      p_user_id,
+      p_command,
+      env_row.cwd,
+      env_row.env,
+      p_replay_of_command_id,
+      p_replay_run_id
+    )
     RETURNING id INTO new_id;
 
   SELECT value INTO channel FROM pg_shell_config WHERE key = 'listen_channel';

--- a/tests/test_replay_agent.py
+++ b/tests/test_replay_agent.py
@@ -30,9 +30,11 @@ class FakeHistoryCursor:
 
 
 class FakeSubmitCursor:
-    def __init__(self):
+    def __init__(self, already_replayed=None):
         self.execute_calls = []
         self.next_id = 1000
+        self._last_exists = None
+        self.already_replayed = set(already_replayed or [])
 
     def __enter__(self):
         return self
@@ -42,8 +44,16 @@ class FakeSubmitCursor:
 
     def execute(self, query, params=None):
         self.execute_calls.append((query, params))
+        if "FROM commands" in query and "replay_of_command_id" in query:
+            self._last_exists = (
+                1 if params and params[1] in self.already_replayed else None
+            )
+        else:
+            self._last_exists = "submit"
 
     def fetchone(self):
+        if self._last_exists != "submit":
+            return [self._last_exists] if self._last_exists else None
         self.next_id += 1
         return [self.next_id]
 
@@ -63,8 +73,8 @@ class FakeHistoryConn:
 
 
 class FakeSubmitConn:
-    def __init__(self):
-        self.cursor_obj = FakeSubmitCursor()
+    def __init__(self, already_replayed=None):
+        self.cursor_obj = FakeSubmitCursor(already_replayed=already_replayed)
         self.commit_count = 0
 
     def __enter__(self):
@@ -111,7 +121,7 @@ def test_replay_commands_streams_large_command_set(monkeypatch):
         replay_agent, "get_conn", FakeConnFactory(history_conn, submit_conn)
     )
     replay_agent.replay_commands("u1", 1)
-    assert submit_conn.commit_count == len(rows)
+    assert submit_conn.commit_count == math.ceil(len(rows) / 100)
     expected_calls = math.ceil(len(rows) / 100) + 1
     assert len(history_conn.cursor_obj.fetchmany_calls) == expected_calls
 
@@ -126,5 +136,60 @@ def test_replay_commands_replays_full_history(monkeypatch):
     replay_agent.replay_commands("u1", 1)
     assert len(submit_conn.cursor_obj.execute_calls) == len(rows)
     submitted_commands = [params for _, params in submit_conn.cursor_obj.execute_calls]
-    assert submitted_commands[0] == ("u1", "cmd0")
-    assert submitted_commands[-1] == ("u1", "cmd149")
+    assert submitted_commands[0][0:2] == ("u1", "cmd0")
+    assert submitted_commands[-1][0:2] == ("u1", "cmd149")
+    assert submitted_commands[0][2] == 0
+    assert submitted_commands[-1][2] == 149
+
+
+def test_replay_commands_resume_skips_already_replayed(monkeypatch):
+    rows = [{"id": i, "command": f"cmd{i}"} for i in range(1, 4)]
+    history_conn = FakeHistoryConn(rows)
+    submit_conn = FakeSubmitConn(already_replayed={1, 2, 3})
+    monkeypatch.setattr(
+        replay_agent, "get_conn", FakeConnFactory(history_conn, submit_conn)
+    )
+
+    replay_agent.replay_commands("u1", 1, resume=True)
+
+    submit_calls = [
+        call
+        for call in submit_conn.cursor_obj.execute_calls
+        if call[0].strip().startswith("SELECT submit_command")
+    ]
+    assert submit_calls == []
+    assert submit_conn.commit_count == 0
+
+
+def test_replay_commands_first_run_then_resume_enqueues_zero_new_rows(monkeypatch):
+    rows = [{"id": i, "command": f"cmd{i}"} for i in range(1, 4)]
+
+    first_history_conn = FakeHistoryConn(rows)
+    first_submit_conn = FakeSubmitConn()
+    monkeypatch.setattr(
+        replay_agent,
+        "get_conn",
+        FakeConnFactory(first_history_conn, first_submit_conn),
+    )
+    replay_agent.replay_commands("u1", 1, resume=True)
+    first_submit_calls = [
+        params
+        for query, params in first_submit_conn.cursor_obj.execute_calls
+        if query.strip().startswith("SELECT submit_command")
+    ]
+    assert len(first_submit_calls) == 3
+
+    second_history_conn = FakeHistoryConn(rows)
+    second_submit_conn = FakeSubmitConn(already_replayed={1, 2, 3})
+    monkeypatch.setattr(
+        replay_agent,
+        "get_conn",
+        FakeConnFactory(second_history_conn, second_submit_conn),
+    )
+    replay_agent.replay_commands("u1", 1, resume=True)
+    second_submit_calls = [
+        params
+        for query, params in second_submit_conn.cursor_obj.execute_calls
+        if query.strip().startswith("SELECT submit_command")
+    ]
+    assert second_submit_calls == []

--- a/workers/replay_agent.py
+++ b/workers/replay_agent.py
@@ -1,13 +1,25 @@
 #!/usr/bin/env python3
 import argparse
 import logging
+import uuid
 
 from psycopg2.extras import RealDictCursor
 
 from workers.db import get_conn
 
 
-def replay_commands(user_id: str, start_id: int) -> None:
+def replay_commands(
+    user_id: str,
+    start_id: int,
+    *,
+    resume: bool = False,
+    force: bool = False,
+    batch_commit_size: int = 100,
+) -> None:
+    if resume and force:
+        raise ValueError("Cannot use --resume and --force together")
+
+    replay_run_id = str(uuid.uuid4())
     with get_conn() as history_conn:
         with history_conn.cursor(cursor_factory=RealDictCursor) as history_cur:
             history_cur.execute(
@@ -21,6 +33,8 @@ def replay_commands(user_id: str, start_id: int) -> None:
             )
             batch_size = 100
             total = 0
+            skipped = 0
+            pending_commits = 0
             with get_conn() as submit_conn:
                 with submit_conn.cursor() as submit_cur:
                     while True:
@@ -30,21 +44,45 @@ def replay_commands(user_id: str, start_id: int) -> None:
                         for row in rows:
                             cmd_id = row["id"]
                             command = row["command"]
+                            if resume and not force:
+                                submit_cur.execute(
+                                    """
+                                    SELECT 1
+                                      FROM commands
+                                     WHERE user_id = %s
+                                       AND replay_of_command_id = %s
+                                     LIMIT 1
+                                    """,
+                                    (user_id, cmd_id),
+                                )
+                                if submit_cur.fetchone() is not None:
+                                    logging.info(
+                                        "Skipping already replayed command %s", cmd_id
+                                    )
+                                    skipped += 1
+                                    continue
                             logging.info(
                                 "Replaying command %s: %s", cmd_id, command
                             )
                             submit_cur.execute(
-                                "SELECT submit_command(%s, %s)",
-                                (user_id, command),
+                                "SELECT submit_command(%s, %s, %s, %s)",
+                                (user_id, command, cmd_id, replay_run_id),
                             )
                             new_id = submit_cur.fetchone()[0]
-                            submit_conn.commit()
+                            pending_commits += 1
+                            if pending_commits >= batch_commit_size:
+                                submit_conn.commit()
+                                pending_commits = 0
                             logging.info("Queued as command %s", new_id)
                             total += 1
+                    if pending_commits:
+                        submit_conn.commit()
             if total == 0:
                 logging.info("no commands to replay")
             else:
-                logging.info("Replayed %d commands", total)
+                logging.info("Replay run %s queued %d commands", replay_run_id, total)
+            if skipped:
+                logging.info("Skipped %d commands already replayed", skipped)
 
 
 def main() -> None:
@@ -53,10 +91,36 @@ def main() -> None:
     parser.add_argument(
         "--start", type=int, required=True, help="Starting command ID"
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip commands already replayed for this user",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow duplicate replay rows even if already replayed",
+    )
+    parser.add_argument(
+        "--commit-every",
+        type=int,
+        default=100,
+        help="Commit after this many submitted replay rows",
+    )
     args = parser.parse_args()
+    if args.commit_every <= 0:
+        parser.error("--commit-every must be greater than zero")
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
     try:
-        replay_commands(args.user, args.start)
+        replay_commands(
+            args.user,
+            args.start,
+            resume=args.resume,
+            force=args.force,
+            batch_commit_size=args.commit_every,
+        )
+    except ValueError as exc:
+        logging.error("Replay agent argument error: %s", exc)
     except RuntimeError as exc:
         logging.error("Replay agent failed to connect to database: %s", exc)
 


### PR DESCRIPTION
### Motivation
- Prevent duplicate replayed commands and provide explicit control over resume vs force behavior when replaying a user session. 
- Attach replay metadata to queued rows so runs are observable and replays can be deduplicated. 
- Improve throughput by committing in batches while preserving visibility of queued work.

### Description
- Add `replay_of_command_id` and `replay_run_id` columns to the `commands` table and create an index `commands_user_replay_source_idx` to speed resume/dedupe lookups. 
- Extend `submit_command` to accept optional `p_replay_of_command_id` and `p_replay_run_id` parameters and persist them with queued rows. 
- Update `workers/replay_agent.py` to generate a per-run `replay_run_id`, support `--resume` (skip already replayed rows) and `--force` (allow duplicates), and add `--commit-every` to control batched commits; resume performs a lookup on `(user_id, replay_of_command_id)` before enqueueing. 
- Add and update unit tests in `tests/test_replay_agent.py` to cover batching semantics, resume/idempotency behavior, and the scenario where a first run enqueues rows and a subsequent resume run enqueues zero new rows.

### Testing
- Ran `pytest -q tests/test_replay_agent.py tests/test_functions.py::test_submit_and_latest_output tests/test_functions.py::test_submit_command_notifies tests/test_functions.py::test_submit_command_respects_configured_channel`, resulting in `5 passed, 3 skipped`.
- New replay-agent unit tests verify that first-run enqueues expected rows and that a second run with `resume` enqueues zero new rows (all assertions pass in CI unit test run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17983e06083289b358bd0cdf3a422)