### PR TITLE
monitor_agent: incremental metric collection with windowing and persisted state

### DIFF
--- a/sql/init_schema.sql
+++ b/sql/init_schema.sql
@@ -32,6 +32,14 @@ CREATE TABLE IF NOT EXISTS pg_shell_config (
   value TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS monitor_state (
+  agent_name TEXT PRIMARY KEY,
+  last_completed_at TIMESTAMP,
+  last_command_id INT,
+  updated_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+
 INSERT INTO pg_shell_config(key, value)
 VALUES ('listen_channel', 'new_command')
 ON CONFLICT (key) DO NOTHING;
@@ -42,3 +50,6 @@ CREATE INDEX IF NOT EXISTS commands_status_submitted_at_idx
 CREATE INDEX IF NOT EXISTS commands_user_id_id_idx
   ON commands (user_id, id);
 
+
+CREATE INDEX IF NOT EXISTS commands_status_completed_at_idx
+  ON commands (status, completed_at, id);

--- a/tests/test_monitor_agent.py
+++ b/tests/test_monitor_agent.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import csv
 
 import workers.monitor_agent as monitor_agent
@@ -14,9 +16,12 @@ def test_collect_metrics_streams(monkeypatch):
     class FakeCursor:
         def __init__(self):
             self.idx = 0
+            self.sql = None
+            self.params = None
 
-        def execute(self, sql):
-            pass
+        def execute(self, sql, params=None):
+            self.sql = sql
+            self.params = params
 
         def fetchone(self):
             fetch_calls.append(self.idx)
@@ -67,6 +72,47 @@ def test_collect_metrics_streams(monkeypatch):
     assert len(captured) == 2
     assert "u2" in captured[0]
     assert "u1" in captured[1]
+    assert "ORDER BY day, user_id" in cursor.sql
+
+
+def test_collect_metrics_uses_incremental_filter_when_state_present():
+    class FakeCursor:
+        def __init__(self):
+            self.sql = None
+            self.params = None
+            self.calls = 0
+
+        def execute(self, sql, params=None):
+            self.sql = sql
+            self.params = params
+
+        def fetchone(self):
+            self.calls += 1
+            return None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    cursor = FakeCursor()
+
+    class FakeConn:
+        def cursor(self, name=None):
+            return cursor
+
+    last_completed = datetime(2024, 1, 1, 10, 0, 0)
+    list(
+        monitor_agent.collect_metrics(
+            FakeConn(),
+            last_completed_at=last_completed,
+            last_command_id=42,
+        )
+    )
+
+    assert "completed_at > %s OR (completed_at = %s AND id > %s)" in cursor.sql
+    assert cursor.params == [last_completed, last_completed, 42]
 
 
 def test_output_metrics_flushes_immediately(tmp_path):
@@ -81,3 +127,16 @@ def test_output_metrics_flushes_immediately(tmp_path):
             contents = reader.read()
 
     assert "u1" in contents
+
+
+def test_compute_since_timestamp_rejects_dual_window_args():
+    class Args:
+        since_hours = 1
+        since_days = 1
+
+    try:
+        monitor_agent.compute_since_timestamp(Args())
+    except ValueError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected ValueError when both windows are set")

--- a/workers/monitor_agent.py
+++ b/workers/monitor_agent.py
@@ -13,31 +13,142 @@ import argparse
 import csv
 import logging
 import time
+from datetime import datetime, timedelta
 from typing import Callable, Iterator, Tuple
 
 from workers.db import get_conn
 
 
 Row = Tuple[str, str, int, float]
+STATE_AGENT_NAME = "monitor_agent"
 
 
-def collect_metrics(conn) -> Iterator[Row]:
-    """Yield metric rows one by one using a server-side cursor."""
-    with conn.cursor(name="monitor_agent_metrics") as cur:
+def ensure_monitor_state_table(conn) -> None:
+    with conn.cursor() as cur:
         cur.execute(
             """
+            CREATE TABLE IF NOT EXISTS monitor_state (
+              agent_name TEXT PRIMARY KEY,
+              last_completed_at TIMESTAMP,
+              last_command_id INT,
+              updated_at TIMESTAMP NOT NULL DEFAULT now()
+            )
+            """
+        )
+
+
+def load_monitor_state(conn) -> tuple[datetime | None, int]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT last_completed_at, COALESCE(last_command_id, 0)
+              FROM monitor_state
+             WHERE agent_name = %s
+            """,
+            (STATE_AGENT_NAME,),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None, 0
+    return row[0], row[1]
+
+
+def save_monitor_state(conn, completed_at: datetime, command_id: int) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO monitor_state (agent_name, last_completed_at, last_command_id, updated_at)
+            VALUES (%s, %s, %s, now())
+            ON CONFLICT (agent_name)
+            DO UPDATE SET
+              last_completed_at = EXCLUDED.last_completed_at,
+              last_command_id = EXCLUDED.last_command_id,
+              updated_at = now()
+            """,
+            (STATE_AGENT_NAME, completed_at, command_id),
+        )
+    conn.commit()
+
+
+def compute_since_timestamp(args: argparse.Namespace) -> datetime | None:
+    if args.since_hours is not None and args.since_days is not None:
+        raise ValueError("--since-hours and --since-days are mutually exclusive")
+    if args.since_hours is not None:
+        return datetime.utcnow() - timedelta(hours=args.since_hours)
+    if args.since_days is not None:
+        return datetime.utcnow() - timedelta(days=args.since_days)
+    return None
+
+
+def collect_metrics(
+    conn,
+    *,
+    since_timestamp: datetime | None = None,
+    last_completed_at: datetime | None = None,
+    last_command_id: int = 0,
+) -> Iterator[Row]:
+    """Yield metric rows one by one using a server-side cursor."""
+
+    predicates = ["status IN ('done', 'failed')", "completed_at IS NOT NULL"]
+    params: list[object] = []
+
+    if since_timestamp is not None:
+        predicates.append("completed_at >= %s")
+        params.append(since_timestamp)
+    elif last_completed_at is not None:
+        predicates.append("(completed_at > %s OR (completed_at = %s AND id > %s))")
+        params.extend([last_completed_at, last_completed_at, last_command_id])
+
+    where_sql = " AND ".join(predicates)
+
+    with conn.cursor(name="monitor_agent_metrics") as cur:
+        cur.execute(
+            f"""
             SELECT user_id,
                    DATE(submitted_at) AS day,
                    COUNT(*) AS command_count,
                    AVG(EXTRACT(EPOCH FROM completed_at - submitted_at)) AS avg_seconds
-             FROM commands
-             WHERE status IN ('done', 'failed') AND completed_at IS NOT NULL
+              FROM commands
+             WHERE {where_sql}
           GROUP BY user_id, day
           ORDER BY day, user_id
-            """
+            """,
+            params,
         )
         for row in iter(cur.fetchone, None):
             yield row
+
+
+def get_watermark(
+    conn,
+    *,
+    since_timestamp: datetime | None = None,
+    last_completed_at: datetime | None = None,
+    last_command_id: int = 0,
+) -> tuple[datetime, int] | None:
+    predicates = ["status IN ('done', 'failed')", "completed_at IS NOT NULL"]
+    params: list[object] = []
+
+    if since_timestamp is not None:
+        predicates.append("completed_at >= %s")
+        params.append(since_timestamp)
+    elif last_completed_at is not None:
+        predicates.append("(completed_at > %s OR (completed_at = %s AND id > %s))")
+        params.extend([last_completed_at, last_completed_at, last_command_id])
+
+    where_sql = " AND ".join(predicates)
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT completed_at, id
+              FROM commands
+             WHERE {where_sql}
+          ORDER BY completed_at DESC, id DESC
+             LIMIT 1
+            """,
+            params,
+        )
+        return cur.fetchone()
 
 
 def output_metrics(
@@ -66,8 +177,24 @@ def main() -> None:
     )
     parser.add_argument("--csv", help="Write metrics to CSV file")
     parser.add_argument("--once", action="store_true", help="Run once then exit")
+    parser.add_argument(
+        "--since-hours",
+        type=int,
+        help="Only consider commands completed in the last N hours",
+    )
+    parser.add_argument(
+        "--since-days",
+        type=int,
+        help="Only consider commands completed in the last N days",
+    )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+
+    try:
+        since_timestamp = compute_since_timestamp(args)
+    except ValueError as exc:
+        logging.error("%s", exc)
+        return 1
 
     def run_loop(
         csv_writer: csv.writer | None,
@@ -84,7 +211,26 @@ def main() -> None:
                 continue
 
             try:
-                output_metrics(collect_metrics(conn), csv_writer, flush)
+                ensure_monitor_state_table(conn)
+                last_completed_at, last_command_id = load_monitor_state(conn)
+                output_metrics(
+                    collect_metrics(
+                        conn,
+                        since_timestamp=since_timestamp,
+                        last_completed_at=last_completed_at,
+                        last_command_id=last_command_id,
+                    ),
+                    csv_writer,
+                    flush,
+                )
+                watermark = get_watermark(
+                    conn,
+                    since_timestamp=since_timestamp,
+                    last_completed_at=last_completed_at,
+                    last_command_id=last_command_id,
+                )
+                if watermark is not None and since_timestamp is None:
+                    save_monitor_state(conn, watermark[0], watermark[1])
             finally:
                 conn.close()
 
@@ -106,6 +252,7 @@ def main() -> None:
             return run_loop(csv_writer, flush)
     else:
         return run_loop(None, None)
+
 
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Avoid full-table metric recomputation on each run by filtering queries to a time window or only newly completed rows. 
- Provide a stable, indexable predicate and watermark so recurring CSV outputs append only new intervals.

### Description
- Added CLI window options `--since-hours` and `--since-days` and a `compute_since_timestamp` helper to convert them into a `completed_at >= ...` filter used in queries.
- Implemented persisted high-water-mark state via a new `monitor_state` table and helper functions `ensure_monitor_state_table`, `load_monitor_state`, and `save_monitor_state` to record `last_completed_at` and `last_command_id` so the agent can query only rows newer than the watermark.
- Reworked `collect_metrics` to accept `since_timestamp`, `last_completed_at`, and `last_command_id` and to build incremental WHERE predicates (`completed_at >= %s` or `(completed_at > %s OR (completed_at = %s AND id > %s))`) while preserving streaming server-side cursor behavior and stable ordering `ORDER BY day, user_id`.
- Added `get_watermark` to compute the latest `(completed_at, id)` after each run and updated CSV mode to append only newly computed intervals because each loop queries only unprocessed rows.
- Updated schema `sql/init_schema.sql` to create `monitor_state` and to add an index `commands_status_completed_at_idx ON commands (status, completed_at, id)` to support the incremental filter efficiently.
- Extended `tests/test_monitor_agent.py` to verify streaming behavior, SQL predicate and bound parameters for incremental mode, stable ordering clause, and window-argument conflict handling.

### Testing
- Ran unit tests for the monitor agent with `pytest -q tests/test_monitor_agent.py` which reported `4 passed`.
- New tests exercise streaming via the server-side cursor, the incremental WHERE clause and params, CSV flush behavior, and rejection of mutually exclusive window args, and all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d179873db08328af8d9e5b6963de65)