### PR TITLE
Fix latest_output runtime bug and run DB-backed tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: pg_shell_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/pg_shell_test
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/sql/latest_output.sql
+++ b/sql/latest_output.sql
@@ -15,19 +15,24 @@ RETURNS TABLE(
     completed_at TIMESTAMP
 ) LANGUAGE plpgsql AS $$
 BEGIN
+    -- Columns are qualified with the table alias so they are not confused
+    -- with the identically named RETURNS TABLE output columns, which would
+    -- otherwise raise "column reference \"id\" is ambiguous".
     IF p_since_id = 0 THEN
         RETURN QUERY
-        SELECT id, command, output, exit_code, status, submitted_at, completed_at
-        FROM commands
-        WHERE user_id = p_user_id AND id > p_since_id
-        ORDER BY id DESC
+        SELECT c.id, c.command, c.output, c.exit_code, c.status,
+               c.submitted_at, c.completed_at
+        FROM commands c
+        WHERE c.user_id = p_user_id AND c.id > p_since_id
+        ORDER BY c.id DESC
         LIMIT 20;
     ELSE
         RETURN QUERY
-        SELECT id, command, output, exit_code, status, submitted_at, completed_at
-        FROM commands
-        WHERE user_id = p_user_id AND id > p_since_id
-        ORDER BY id ASC;
+        SELECT c.id, c.command, c.output, c.exit_code, c.status,
+               c.submitted_at, c.completed_at
+        FROM commands c
+        WHERE c.user_id = p_user_id AND c.id > p_since_id
+        ORDER BY c.id ASC;
     END IF;
 END;
 $$;

--- a/tests/test_cleanup_agent.py
+++ b/tests/test_cleanup_agent.py
@@ -61,8 +61,11 @@ def test_cleanup_once_resets_env(conn):
 def test_cleanup_once_resets_multiple_envs(conn, caplog):
     ids = [str(uuid.uuid4()) for _ in range(2)]
     with conn.cursor() as cur:
-        for uid in ids:
-            cur.execute("INSERT INTO users (id, username) VALUES (%s, %s)", (uid, "user"))
+        for i, uid in enumerate(ids):
+            cur.execute(
+                "INSERT INTO users (id, username) VALUES (%s, %s)",
+                (uid, f"multiuser{i}"),
+            )
             cur.execute(
                 "INSERT INTO environments (user_id, cwd, env, updated_at) VALUES (%s, %s, %s::jsonb, now() - interval '100 days')",
                 (uid, '/tmp', '{"k":1}')
@@ -76,7 +79,7 @@ def test_cleanup_once_resets_multiple_envs(conn, caplog):
     assert "Reset 2 stale environments" in caplog.text
     with conn.cursor() as cur:
         cur.execute(
-            "SELECT cwd, env FROM environments WHERE user_id = ANY(%s) ORDER BY user_id",
+            "SELECT cwd, env FROM environments WHERE user_id = ANY(%s::uuid[]) ORDER BY user_id",
             (ids,)
         )
         rows = cur.fetchall()

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -249,6 +249,11 @@ def test_command_indexes_query_plans(conn):
                 (secondary_user, f'spare {i}', 'pending', i),
             )
 
+        # Refresh planner statistics so index selection reflects the data we
+        # just inserted; without this the planner works from empty-table stats
+        # and may pick an unrelated index.
+        cur.execute("ANALYZE commands")
+
         cur.execute(
             "EXPLAIN (FORMAT JSON) "
             "SELECT id FROM commands WHERE status = 'pending' ORDER BY submitted_at LIMIT 5"


### PR DESCRIPTION
## Summary

CI ran `pytest` without a PostgreSQL service, so every database-backed test
**silently skipped** (10 of 35). That blind spot let two real defects ship to
`main`. This PR makes CI actually exercise the database, then fixes everything
the now-running tests surface.

## Root cause

The `test` job had no Postgres service and never set `TEST_DATABASE_URL`, so the
DB fixtures hit `pytest.skip(...)`. Locally, running the suite against a real
Postgres 16 produced 4 failures.

## Changes

**Production bug**
- `sql/latest_output.sql`: the function failed at runtime with
  `column reference "id" is ambiguous` — the `RETURNS TABLE` output columns
  (`id`, `command`, …) collide with the selected `commands` columns inside the
  `RETURN QUERY`. The SPEC's core read endpoint was completely non-functional.
  Fixed by qualifying every column with a table alias (`c.id`, `c.command`, …).

**Test correctness**
- `tests/test_cleanup_agent.py`: `test_cleanup_once_resets_multiple_envs`
  inserted two users with the same username (violating the `UNIQUE` constraint)
  and compared `uuid = text` in its verification query. Now uses distinct
  usernames and casts the array parameter (`ANY(%s::uuid[])`).
- `tests/test_functions.py`: `test_command_indexes_query_plans` never ran
  `ANALYZE`, so the planner chose an index from empty-table statistics
  (`commands_status_completed_at_idx` instead of the expected
  `commands_status_submitted_at_idx`). Added `ANALYZE commands` before
  `EXPLAIN`; the planner then picks the correct index.

**CI**
- `.github/workflows/ci.yml`: added a `postgres:16` service (with a
  `pg_isready` healthcheck) and `TEST_DATABASE_URL` so the database tests run on
  every push and pull request.

## Verification

- Against a live Postgres 16: **35 passed** (was 4 failed / 31 passed).
- Without a database (mirrors the old CI): **25 passed, 10 skipped** — the suite
  still degrades gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BixPb34oe2Ae5cXuz9WxbP)_