### PR TITLE
Add coverage for executor timeouts, env snapshot, and cleanup retention

### DIFF
--- a/tests/test_cleanup_agent.py
+++ b/tests/test_cleanup_agent.py
@@ -35,6 +35,47 @@ def conn():
     conn.close()
 
 
+def test_cleanup_once_deletes_only_old_completed_commands(conn):
+    uid_str = str(uuid.uuid4())
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (id, username) VALUES (%s, %s)", (uid_str, "deluser")
+        )
+        # Old + done -> deleted
+        cur.execute(
+            "INSERT INTO commands (user_id, command, submitted_at, status) "
+            "VALUES (%s, 'old-done', now() - interval '100 days', 'done') RETURNING id",
+            (uid_str,),
+        )
+        old_done_id = cur.fetchone()[0]
+        # Old but not done -> preserved (cleanup only targets completed history)
+        cur.execute(
+            "INSERT INTO commands (user_id, command, submitted_at, status) "
+            "VALUES (%s, 'old-failed', now() - interval '100 days', 'failed') RETURNING id",
+            (uid_str,),
+        )
+        old_failed_id = cur.fetchone()[0]
+        # Recent + done -> preserved (still within retention window)
+        cur.execute(
+            "INSERT INTO commands (user_id, command, submitted_at, status) "
+            "VALUES (%s, 'recent-done', now(), 'done') RETURNING id",
+            (uid_str,),
+        )
+        recent_done_id = cur.fetchone()[0]
+
+    cleanup_once(conn, 90)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM commands WHERE user_id = %s ORDER BY id", (uid_str,)
+        )
+        remaining = [row[0] for row in cur.fetchall()]
+
+    assert old_done_id not in remaining
+    assert old_failed_id in remaining
+    assert recent_done_id in remaining
+
+
 def test_cleanup_once_resets_env(conn):
     uid_str = str(uuid.uuid4())
     with conn.cursor() as cur:

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -29,6 +29,22 @@ def test_run_subprocess_preserves_exit_code(monkeypatch, tmp_path):
     assert output.endswith("...[truncated]")
 
 
+def test_run_subprocess_times_out(monkeypatch, tmp_path):
+    # SPEC section 7 requires command timeouts to be enforced. A command that
+    # outruns COMMAND_TIMEOUT is killed and reported with exit code 124.
+    monkeypatch.setattr(workers.executor_agent, "COMMAND_TIMEOUT", 1)
+    exit_code, output = run_subprocess("sleep 5", str(tmp_path), None)
+    assert exit_code == 124
+    assert "Timed out after 1s" in output
+
+
+def test_run_subprocess_passes_env_snapshot(monkeypatch, tmp_path):
+    cmd = "python3 -c 'import os;print(os.environ[\"PGS_TEST_VAR\"])'"
+    exit_code, output = run_subprocess(cmd, str(tmp_path), {"PGS_TEST_VAR": "hello"})
+    assert exit_code == 0
+    assert "hello" in output
+
+
 def test_handle_command_uses_combined_output(monkeypatch):
     captured = {}
 
@@ -265,6 +281,31 @@ def test_handle_command_malformed_command(monkeypatch):
     assert captured['status'] == 'failed'
     assert captured['exit_code'] == 1
     assert 'No closing quotation' in captured['output']
+
+
+def test_handle_command_missing_binary_marks_failed(monkeypatch, tmp_path):
+    captured: dict = {}
+
+    def fake_update_command(conn, cmd_id, status, output, exit_code):
+        captured['status'] = status
+        captured['output'] = output
+        captured['exit_code'] = exit_code
+
+    monkeypatch.setattr('workers.executor_agent.update_command', fake_update_command)
+
+    row = {
+        'id': 7,
+        'user_id': 'u1',
+        'command': 'definitely_not_a_real_binary_xyz',
+        'cwd_snapshot': str(tmp_path),
+        'env_snapshot': None,
+    }
+
+    handle_command(None, row)
+
+    assert captured['status'] == 'failed'
+    assert captured['exit_code'] == 1
+    assert 'No such file or directory' in captured['output']
 
 
 def test_main_closes_connection_on_keyboard_interrupt(monkeypatch):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -177,9 +177,10 @@ def test_fork_session_same_user_source_command_succeeds(conn):
         )
         cur.execute("SELECT fork_session(%s, %s)", (user_id, cmd_id))
         cur.fetchone()
-        cur.execute("SELECT cwd FROM environments WHERE user_id=%s", (user_id,))
-        cwd = cur.fetchone()[0]
+        cur.execute("SELECT cwd, env FROM environments WHERE user_id=%s", (user_id,))
+        cwd, env = cur.fetchone()
         assert cwd == '/home/start'
+        assert env == {"FOO": "BAR"}
 
 
 def test_fork_session_different_user_source_command_fails(conn):


### PR DESCRIPTION
## Summary

Adds tests for executor and cleanup behavior that previously had **no coverage**.
Follow-up to #57 (now merged), which wired the Postgres service into CI so the
database-backed test here actually runs instead of skipping.

## New / strengthened tests

- **Command timeout enforcement** (`run_subprocess`) — SPEC §7 requires timeouts
  to be enforced, but nothing tested it. New test runs `sleep 5` with a 1s
  `COMMAND_TIMEOUT` and asserts the process is killed and reported as exit code
  `124` with a `Timed out after 1s` message.
- **Env snapshot propagation** (`run_subprocess`) — asserts a variable from the
  command's `env_snapshot` reaches the child process.
- **Missing binary handling** (`handle_command`) — asserts a non-existent command
  is recorded as `failed` / exit `1` rather than crashing the worker loop.
- **Cleanup retention** (`cleanup_once`) — asserts only *old + completed* (`done`)
  commands are deleted, while recent commands and old non-completed history are
  preserved.
- **`fork_session`** — strengthened the existing test to assert the environment
  **`env` snapshot** is copied, not just the working directory.

## Verification

- Against a live Postgres 16: **39 passed** (was 35).
- Without a database: **28 passed, 11 skipped** — the three new subprocess-level
  executor tests run without a DB; the new cleanup test skips gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BixPb34oe2Ae5cXuz9WxbP)_