### PR TITLE
Align REST client payloads with p_-prefixed function parameters

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -103,8 +103,8 @@ Requests/responses in JSON.
   hx-target="#output"
   hx-swap="beforeend"
 >
-  <input type="hidden" name="user_id" value="USER_ID" />
-  <input name="command" autocomplete="off" autofocus placeholder="Enter command…" />
+  <input type="hidden" name="p_user_id" value="USER_ID" />
+  <input name="p_command" autocomplete="off" autofocus placeholder="Enter command…" />
 </form>
 ```
 

--- a/cli/shell_cli.py
+++ b/cli/shell_cli.py
@@ -72,7 +72,7 @@ def exec_command(
     try:
         resp = requests.post(
             f"{base_url}/rpc/submit_command",
-            json={"user_id": user_id, "command": cmd},
+            json={"p_user_id": user_id, "p_command": cmd},
             timeout=timeout,
             headers=_POST_HEADERS,
         )
@@ -110,7 +110,7 @@ def fork_session(
     try:
         resp = requests.post(
             f"{base_url}/rpc/fork_session",
-            json={"user_id": user_id, "source_command_id": command_id},
+            json={"p_user_id": user_id, "p_source_command_id": command_id},
             timeout=timeout,
             headers=_POST_HEADERS,
         )

--- a/html/index.html
+++ b/html/index.html
@@ -21,8 +21,8 @@
   hx-ext="json-enc"
   hx-encoding="json"
 >
-  <input type="hidden" name="user_id" value="USER_ID" />
-  <input name="command" autocomplete="off" autofocus placeholder="Enter command…" />
+  <input type="hidden" name="p_user_id" value="USER_ID" />
+  <input name="p_command" autocomplete="off" autofocus placeholder="Enter command…" />
 </form>
 </body>
 </html>

--- a/tests/test_shell_cli.py
+++ b/tests/test_shell_cli.py
@@ -15,7 +15,9 @@ def test_exec_command_posts_with_prefer_headers(monkeypatch, capsys):
 
     def fake_post(url, json, timeout, headers):
         assert url == "http://example/rpc/submit_command"
-        assert json == {"user_id": "u1", "command": "ls"}
+        # PostgREST maps JSON body keys to function argument names, so the
+        # keys must match submit_command(p_user_id, p_command).
+        assert json == {"p_user_id": "u1", "p_command": "ls"}
         assert timeout == 5
         assert headers["Prefer"] == "return=representation"
         assert headers["Accept"] == "application/json"
@@ -27,6 +29,29 @@ def test_exec_command_posts_with_prefer_headers(monkeypatch, capsys):
     assert rc == 0
     captured = capsys.readouterr()
     assert captured.out.strip() == "{'status': 'ok'}"
+
+
+def test_fork_session_posts_prefixed_arguments(monkeypatch, capsys):
+    class Resp:
+        text = ""
+        status_code = 200
+        reason = "OK"
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"fork_session": "u1"}
+
+    def fake_post(url, json, timeout, headers):
+        assert url == "http://example/rpc/fork_session"
+        assert json == {"p_user_id": "u1", "p_source_command_id": 7}
+        return Resp()
+
+    monkeypatch.setattr(sc.requests, "post", fake_post)
+
+    rc = sc.fork_session("http://example", "u1", 7)
+    assert rc == 0
 
 
 def test_exec_command_handles_empty_response(monkeypatch, capsys):


### PR DESCRIPTION
## Summary

PostgREST maps JSON body keys to the called function's **argument names**. The
`submit_command` and `fork_session` functions declare `p_user_id` / `p_command`
/ `p_source_command_id`, but the HTML form and CLI were posting **unprefixed**
keys (`user_id` / `command` / `source_command_id`). Against a real PostgREST
deployment those POSTs fail to resolve the function. The `GET` path for
`latest_output` already uses `p_user_id`, so this brings the write paths in line
with the rest of the project.

## Changes

- `html/index.html` — form fields renamed to `p_user_id` / `p_command`.
- `cli/shell_cli.py` — `exec_command` and `fork_session` send `p_`-prefixed keys.
- `SPEC.md` — the §5 form example matches.
- `tests/test_shell_cli.py` — updated the `exec` body assertion and added a
  `fork_session` test that pins the `p_`-prefixed argument names.

## Why this direction

All six SQL function parameters use the `p_` prefix, the README documents
`submit_command(p_user_id, p_command)`, and the existing GET path already sends
`p_user_id` — so aligning the three POST call sites to `p_` is the minimal,
consistent fix and requires **no database/contract change**. The alternative
(renaming the DB params to drop `p_`) would also require touching the
already-working GET path. If you'd prefer that direction instead, this is easy
to flip.

## Out of scope

I left the `?p_user_id=eq.<uuid>` filter style on the `latest_output` GET path
untouched — it's consistent across the SPEC, HTML, CLI, and its tests, and
verifying any change there needs a live PostgREST instance.

## Verification

- Full suite against a live Postgres 16: **43 passed**.
- CLI tests (including the new fork-session test): pass without a database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BixPb34oe2Ae5cXuz9WxbP)_