### PR TITLE
Remove dangling AGENTS.md references from SQL comments

### DIFF
--- a/sql/fork_session.sql
+++ b/sql/fork_session.sql
@@ -1,5 +1,5 @@
 -- fork_session: creates a new environment from a command snapshot
--- Refers to SPEC.md for snapshot fields and AGENTS.md for replay_agent usage
+-- Refers to SPEC.md for snapshot fields; used by workers/replay_agent.py
 
 CREATE OR REPLACE FUNCTION fork_session(p_user_id UUID, p_source_command_id INTEGER)
 RETURNS UUID LANGUAGE plpgsql AS $$

--- a/sql/submit_command.sql
+++ b/sql/submit_command.sql
@@ -1,5 +1,5 @@
 -- submit_command: queues a command for execution
--- References SPEC.md (RPC function) and executor_agent in AGENTS.md
+-- References SPEC.md (RPC function); consumed by workers/executor_agent.py
 
 CREATE OR REPLACE FUNCTION submit_command(
   p_user_id UUID,


### PR DESCRIPTION
## Summary

`AGENTS.md` was deleted from the repository, but two SQL file header comments
still pointed at it:

- `sql/submit_command.sql` — "…and executor_agent in AGENTS.md"
- `sql/fork_session.sql` — "…and AGENTS.md for replay_agent usage"

This replaces those dead references with pointers to the worker modules that
actually consume each function (`workers/executor_agent.py`,
`workers/replay_agent.py`).

Comment-only change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BixPb34oe2Ae5cXuz9WxbP)_