### PR TITLE
Implement replay_session RPC and wire up the CLI replay command

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -59,6 +59,12 @@ CREATE INDEX commands_user_id_id_idx ON commands (user_id, id);
 
 - Creates a new `environments` entry based on historical snapshot
 
+### `replay_session(user_id UUID, start_id INTEGER) RETURNS UUID`
+
+- Re-queues the user's original commands with `id >= start_id`, in order
+- Each replayed command is tagged with `replay_of_command_id` and a shared `replay_run_id`
+- Returns the `replay_run_id` grouping the queued commands
+
 ---
 
 ## 3. Execution Backend

--- a/cli/shell_cli.py
+++ b/cli/shell_cli.py
@@ -123,15 +123,22 @@ def fork_session(
     return 0
 
 
-def replay_session(base_url: str, session: str, timeout: float = DEFAULT_TIMEOUT) -> int:
-    """Request a replay of a past session.
+def replay_session(
+    base_url: str, user_id: str, start_id: int, timeout: float = DEFAULT_TIMEOUT
+) -> int:
+    """Replay a user's command history from a starting command.
+
+    Re-queues the user's original commands with id ``>= start_id`` via the
+    ``replay_session`` RPC and prints the returned replay run id.
 
     Parameters
     ----------
     base_url : str
         PostgREST base URL.
-    session : str
-        Timestamp or session ID to replay.
+    user_id : str
+        User whose history is replayed.
+    start_id : int
+        Command id marking the start of the session to replay.
     timeout : float, optional
         HTTP request timeout seconds.
 
@@ -144,7 +151,7 @@ def replay_session(base_url: str, session: str, timeout: float = DEFAULT_TIMEOUT
     try:
         resp = requests.post(
             f"{base_url}/rpc/replay_session",
-            json={"session": session},
+            json={"p_user_id": user_id, "p_start_id": start_id},
             timeout=timeout,
             headers=_POST_HEADERS,
         )
@@ -254,8 +261,11 @@ def main(argv: list[str] | None = None) -> int:
     exec_p.add_argument("--user", required=True, help="User ID")
     exec_p.add_argument("--cmd", required=True, help="Command text")
 
-    replay_p = sub.add_parser("replay", help="Replay a session")
-    replay_p.add_argument("--session", required=True, help="Session timestamp or ID")
+    replay_p = sub.add_parser("replay", help="Replay a session from a starting command")
+    replay_p.add_argument("--user", required=True, help="User ID")
+    replay_p.add_argument(
+        "--start", type=int, required=True, help="Command ID to start replaying from"
+    )
 
     fork_p = sub.add_parser("fork", help="Fork session at a command")
     fork_p.add_argument("--user", required=True, help="User ID")
@@ -272,7 +282,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "exec":
         rc = exec_command(args.base_url, args.user, args.cmd, args.timeout)
     elif args.command == "replay":
-        rc = replay_session(args.base_url, args.session, args.timeout)
+        rc = replay_session(args.base_url, args.user, args.start, args.timeout)
     elif args.command == "fork":
         rc = fork_session(args.base_url, args.user, args.at, args.timeout)
     elif args.command == "tail":

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -3,6 +3,7 @@
 \i sql/submit_command.sql
 \i sql/latest_output.sql -- updated latest_output with optional since_id filter
 \i sql/fork_session.sql
+\i sql/replay_session.sql
 
 -- Ensure supporting indexes exist on commands for executor and query performance
 CREATE INDEX IF NOT EXISTS commands_status_submitted_at_idx ON commands (status, submitted_at);

--- a/sql/replay_session.sql
+++ b/sql/replay_session.sql
@@ -1,0 +1,42 @@
+-- replay_session: re-queues a user's command history from a starting point.
+--
+-- Implements the replay flow described in SPEC.md section 6 ("pull all
+-- commands >= session start, apply in order") as a callable RPC, mirroring
+-- workers/replay_agent.py. Each replayed command is queued through
+-- submit_command so it is tagged with replay_of_command_id (the original
+-- command) and a shared replay_run_id, and the executor is notified.
+--
+-- Only original commands (replay_of_command_id IS NULL) are replayed so that
+-- replaying a range which already contains prior replays cannot snowball.
+-- Returns the replay_run_id grouping the newly queued commands.
+
+CREATE OR REPLACE FUNCTION replay_session(
+  p_user_id UUID,
+  p_start_id INTEGER
+)
+RETURNS UUID LANGUAGE plpgsql AS $$
+DECLARE
+  run_id UUID := gen_random_uuid();
+  rec RECORD;
+BEGIN
+  -- Validate the user up front, matching submit_command's contract.
+  PERFORM 1 FROM users WHERE id = p_user_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Unknown user_id: %. Create the user before replaying.', p_user_id
+      USING ERRCODE = '22023';
+  END IF;
+
+  FOR rec IN
+    SELECT id, command
+      FROM commands
+     WHERE user_id = p_user_id
+       AND id >= p_start_id
+       AND replay_of_command_id IS NULL
+     ORDER BY id ASC
+  LOOP
+    PERFORM submit_command(p_user_id, rec.command, rec.id, run_id);
+  END LOOP;
+
+  RETURN run_id;
+END;
+$$;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ SQL_FILES = (
     "sql/submit_command.sql",
     "sql/latest_output.sql",
     "sql/fork_session.sql",
+    "sql/replay_session.sql",
 )
 
 # Tables dropped before (re)installing the schema for a clean slate.

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -229,6 +229,73 @@ def test_latest_output_since_id(conn):
         assert [row[0] for row in rows] == expected_ids
 
 
+def test_replay_session_requeues_from_start(conn):
+    user_id = str(uuid.uuid4())
+    with conn.cursor() as cur:
+        cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (user_id, "replayer"))
+        original_ids = []
+        for idx in range(3):
+            cur.execute("SELECT submit_command(%s, %s)", (user_id, f"echo r{idx}"))
+            original_ids.append(cur.fetchone()[0])
+
+        start_id = original_ids[1]
+        cur.execute("SELECT replay_session(%s, %s)", (user_id, start_id))
+        run_id = cur.fetchone()[0]
+        assert run_id is not None
+
+        # Replayed rows reference the originals at/after start_id, share the
+        # returned run id, and are queued as fresh pending work.
+        cur.execute(
+            """
+            SELECT command, replay_of_command_id, replay_run_id, status
+              FROM commands
+             WHERE replay_run_id = %s
+             ORDER BY id
+            """,
+            (run_id,),
+        )
+        replayed = cur.fetchall()
+
+    assert [r[0] for r in replayed] == ["echo r1", "echo r2"]
+    assert [r[1] for r in replayed] == original_ids[1:]
+    assert all(str(r[2]) == str(run_id) for r in replayed)
+    assert all(r[3] == "pending" for r in replayed)
+
+
+def test_replay_session_only_replays_originals(conn):
+    user_id = str(uuid.uuid4())
+    with conn.cursor() as cur:
+        cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (user_id, "replayer2"))
+        cur.execute("SELECT submit_command(%s, %s)", (user_id, "echo once"))
+        original_id = cur.fetchone()[0]
+
+        # First replay creates one replayed row.
+        cur.execute("SELECT replay_session(%s, %s)", (user_id, original_id))
+        cur.fetchone()
+
+        # Second replay from the same start must re-queue only the original,
+        # not the row produced by the first replay.
+        cur.execute("SELECT replay_session(%s, %s)", (user_id, original_id))
+        second_run = cur.fetchone()[0]
+
+        cur.execute(
+            "SELECT replay_of_command_id FROM commands WHERE replay_run_id = %s",
+            (second_run,),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) == 1
+    assert rows[0][0] == original_id
+
+
+def test_replay_session_unknown_user_raises(conn):
+    missing_user = str(uuid.uuid4())
+    with conn.cursor() as cur:
+        with pytest.raises(psycopg2.Error) as exc_info:
+            cur.execute("SELECT replay_session(%s, %s)", (missing_user, 1))
+    assert exc_info.value.pgcode == "22023"
+
+
 def test_command_indexes_query_plans(conn):
     primary_user = str(uuid.uuid4())
     secondary_user = str(uuid.uuid4())

--- a/tests/test_shell_cli.py
+++ b/tests/test_shell_cli.py
@@ -54,6 +54,44 @@ def test_fork_session_posts_prefixed_arguments(monkeypatch, capsys):
     assert rc == 0
 
 
+def test_replay_session_posts_prefixed_arguments(monkeypatch, capsys):
+    class Resp:
+        text = ""
+        status_code = 200
+        reason = "OK"
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"replay_session": "00000000-0000-0000-0000-000000000000"}
+
+    def fake_post(url, json, timeout, headers):
+        assert url == "http://example/rpc/replay_session"
+        assert json == {"p_user_id": "u1", "p_start_id": 5}
+        return Resp()
+
+    monkeypatch.setattr(sc.requests, "post", fake_post)
+
+    rc = sc.replay_session("http://example", "u1", 5)
+    assert rc == 0
+
+
+def test_main_replay_dispatches_user_and_start(monkeypatch):
+    captured = {}
+
+    def fake_replay(base_url, user_id, start_id, timeout):
+        captured["args"] = (base_url, user_id, start_id)
+        return 0
+
+    monkeypatch.setattr(sc, "replay_session", fake_replay)
+    rc = sc.main(
+        ["--base-url", "http://example", "replay", "--user", "u1", "--start", "5"]
+    )
+    assert rc == 0
+    assert captured["args"] == ("http://example", "u1", 5)
+
+
 def test_exec_command_handles_empty_response(monkeypatch, capsys):
     class Resp:
         text = ""


### PR DESCRIPTION
## Summary

The CLI `replay` command POSTed to `/rpc/replay_session`, but no such function
existed — so it always failed. This implements the function (a v0.3 roadmap
item) and makes the command work end to end.

## Changes

- **`sql/replay_session.sql`** — `replay_session(user_id UUID, start_id INTEGER)
  RETURNS UUID`. Re-queues the user's **original** commands
  (`replay_of_command_id IS NULL`) with `id >= start_id`, in order, by calling
  `submit_command` for each — so every replayed row is tagged with
  `replay_of_command_id` (the source) and a shared `replay_run_id`, and the
  executor is notified. Validates the user up front (SQLSTATE `22023`) and
  returns the run id. This mirrors `workers/replay_agent.py`. Replaying only
  originals means a range that already contains prior replays can't snowball.
- **`sql/install.sql`** / **`tests/conftest.py`** — install the new function.
- **`cli/shell_cli.py`** — the `replay` subcommand now takes `--user` / `--start`
  and posts `p_user_id` / `p_start_id`, consistent with the other RPC clients.
  (The old `--session` arg pointed at a non-existent endpoint.)
- **`SPEC.md`** — documents the new RPC under §2.

## Tests

- SQL (DB-backed): requeue-from-start tagging/ordering, originals-only on
  repeat replay, and unknown-user error.
- CLI: replay posts the correct prefixed args, and `main` dispatches
  `--user`/`--start` correctly.

## Verification

- Full suite against a live Postgres 16: **48 passed**.
- `install.sql` applies cleanly; manual end-to-end shows `replay_session` returns
  a run id and queues the originals as new pending rows tagged to their sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BixPb34oe2Ae5cXuz9WxbP)_