### PR TITLE
Pass plain user IDs to latest_output RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ cd html && python3 -m http.server 8080
 
 When running PostgREST you can also point `server-static-path` to this
 folder so the UI is served alongside your RPC endpoints.
+
+Poll a user's output by passing the RPC arguments directly. PostgREST casts
+the plain UUID and integer values to the `latest_output(UUID, INTEGER)`
+function parameters:
+
+```bash
+curl "http://localhost:3000/rpc/latest_output?p_user_id=00000000-0000-0000-0000-000000000000&p_since_id=0"
+```
+
 ## Running Tests
 
 Tests require a PostgreSQL database. Set `TEST_DATABASE_URL` to a DSN with privileges to create tables. Then run:

--- a/SPEC.md
+++ b/SPEC.md
@@ -51,7 +51,7 @@ CREATE INDEX commands_user_id_id_idx ON commands (user_id, id);
 - Requires `user_id` to already exist in `users`; raises SQLSTATE `22023` with a user-friendly error for unknown users
 - Returns `commands.id`
 
-### `latest_output(user_id UUID) RETURNS TABLE(id, command, output, exit_code, status, submitted_at)`
+### `latest_output(p_user_id UUID, p_since_id INTEGER DEFAULT 0) RETURNS TABLE(id, command, output, exit_code, status, submitted_at, completed_at)`
 
 - Returns last *N* commands for user
 
@@ -85,7 +85,7 @@ Execution must:
 ## 4. REST Interface (via PostgREST)
 
 - `POST /rpc/submit_command`
-- `GET /rpc/latest_output?p_user_id=eq.{uuid}`
+- `GET /rpc/latest_output?p_user_id={uuid}&p_since_id=0`
 - `POST /rpc/fork_session`
 
 Requests/responses in JSON.
@@ -98,7 +98,7 @@ Requests/responses in JSON.
 
 ```html
 <div id="output"
-  hx-get="/rpc/latest_output?p_user_id=eq.USER_ID"
+  hx-get="/rpc/latest_output?p_user_id=USER_ID"
   hx-trigger="load, every 1s"
   hx-swap="innerHTML">
 </div>

--- a/cli/shell_cli.py
+++ b/cli/shell_cli.py
@@ -186,7 +186,7 @@ def tail_output(
     polls_remaining = max_polls
     try:
         while True:
-            params = {"p_user_id": f"eq.{user_id}"}
+            params = {"p_user_id": user_id}
 
             if last_id is not None:
                 params["p_since_id"] = last_id

--- a/html/index.html
+++ b/html/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <div id="output"
-  hx-get="/rpc/latest_output?p_user_id=eq.USER_ID"
+  hx-get="/rpc/latest_output?p_user_id=USER_ID"
   hx-trigger="load, every 1s"
   hx-swap="innerHTML">
 </div>

--- a/tests/test_postgrest_integration.py
+++ b/tests/test_postgrest_integration.py
@@ -1,0 +1,42 @@
+"""Integration coverage for requests sent to a live PostgREST instance."""
+
+import os
+import uuid
+
+import pytest
+
+from cli.shell_cli import tail_output
+
+
+def test_tail_output_invokes_latest_output_through_postgrest(db_conn, capsys):
+    """A CLI-generated query resolves latest_output(UUID, INTEGER)."""
+    base_url = os.environ.get("TEST_POSTGREST_URL")
+    if not base_url:
+        pytest.skip("TEST_POSTGREST_URL not set")
+
+    user_id = str(uuid.uuid4())
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users(id, username) VALUES (%s, %s)",
+            (user_id, f"postgrest-{user_id}"),
+        )
+        cur.execute("SELECT submit_command(%s, %s)", (user_id, "echo integration"))
+        command_id = cur.fetchone()[0]
+        cur.execute(
+            """
+            UPDATE commands
+               SET output = 'integration', exit_code = 0, status = 'done',
+                   completed_at = now()
+             WHERE id = %s
+            """,
+            (command_id,),
+        )
+
+    assert tail_output(
+        base_url.rstrip("/"), user_id, since=0, interval=0, max_polls=1
+    ) == 0
+    assert capsys.readouterr().out.splitlines() == [
+        "$ echo integration",
+        "integration",
+        "(exit 0)",
+    ]

--- a/tests/test_shell_cli.py
+++ b/tests/test_shell_cli.py
@@ -209,7 +209,7 @@ def test_tail_output_waits_for_terminal_status(monkeypatch, capsys):
     ]
 
     assert call_params == [
-        {'p_user_id': 'eq.u1'},
-        {'p_user_id': 'eq.u1'},
-        {'p_user_id': 'eq.u1', 'p_since_id': 1},
+        {'p_user_id': 'u1'},
+        {'p_user_id': 'u1'},
+        {'p_user_id': 'u1', 'p_since_id': 1},
     ]


### PR DESCRIPTION
### Motivation

- PostgREST RPC parameters should be passed as plain values rather than PostgREST filter expressions so `latest_output(UUID, INTEGER)` is invoked directly.

### Description

- Send `p_user_id` as the raw `user_id` in the CLI poll request by changing `params` in `tail_output` from `{"p_user_id": f"eq.{user_id}"}` to `{"p_user_id": user_id}` (`cli/shell_cli.py`).
- Update the htmx polling URL to use `p_user_id=USER_ID` instead of `p_user_id=eq.USER_ID` (`html/index.html`).
- Update examples and the RPC signature in docs to reflect `latest_output(p_user_id UUID, p_since_id INTEGER DEFAULT 0)` and show direct PostgREST argument usage (`SPEC.md`, `README.md`).
- Adjust unit test assertions in `tests/test_shell_cli.py` to expect plain user IDs in request params.
- Add an environment-gated integration test `tests/test_postgrest_integration.py` that inserts a user and a completed command into the test database and asserts `tail_output` (when pointed at a live PostgREST via `TEST_POSTGREST_URL`) resolves `latest_output(UUID, INTEGER)` and prints the expected output.

### Testing

- Ran the full test suite with `python -m pytest -q`, which reported `31 passed, 18 skipped` and succeeded locally; database and PostgREST integration tests are skipped when their environment variables are not set.
- Added integration test is gated by `TEST_POSTGREST_URL` and will `pytest.skip` when that environment variable is absent, so CI without a PostgREST instance remains green.
- Confirmed `git diff --check` showed no whitespace errors and the working tree was clean after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b85c2ea608328ae1b338053a40f5f)