### PR TITLE
Preserve replay data when original commands expire

### DIFF
--- a/sql/init_schema.sql
+++ b/sql/init_schema.sql
@@ -17,7 +17,9 @@ CREATE TABLE IF NOT EXISTS commands (
   id SERIAL PRIMARY KEY,
   user_id UUID NOT NULL REFERENCES users(id),
   command TEXT NOT NULL,
-  replay_of_command_id INT REFERENCES commands(id),
+  -- Replay rows are retained independently of their source command. Once the
+  -- source ages out, its nullable provenance link is cleared.
+  replay_of_command_id INT REFERENCES commands(id) ON DELETE SET NULL,
   replay_run_id UUID,
   submitted_at TIMESTAMP NOT NULL DEFAULT now(),
   status TEXT NOT NULL DEFAULT 'pending',

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -1,5 +1,6 @@
 -- install.sql: convenience script to install pg_shell schema and functions
 \i sql/init_schema.sql
+\i sql/migrate_replay_provenance_retention.sql
 \i sql/submit_command.sql
 \i sql/latest_output.sql -- updated latest_output with optional since_id filter
 \i sql/fork_session.sql

--- a/sql/migrate_replay_provenance_retention.sql
+++ b/sql/migrate_replay_provenance_retention.sql
@@ -1,0 +1,41 @@
+-- Replay command data has its own retention lifetime.  Expiring an original
+-- command therefore clears the replay's provenance link instead of deleting
+-- the replay or preventing cleanup of the original.
+--
+-- This block is safe to run repeatedly and also tolerates a non-default name
+-- for the existing single-column foreign-key constraint.
+DO $$
+DECLARE
+  replay_fk_name TEXT;
+  replay_fk_delete_action "char";
+BEGIN
+  SELECT constraint_row.conname, constraint_row.confdeltype
+    INTO replay_fk_name, replay_fk_delete_action
+    FROM pg_constraint AS constraint_row
+   WHERE constraint_row.conrelid = 'commands'::regclass
+     AND constraint_row.contype = 'f'
+     AND constraint_row.conkey = ARRAY[
+           (SELECT column_row.attnum
+              FROM pg_attribute AS column_row
+             WHERE column_row.attrelid = 'commands'::regclass
+               AND column_row.attname = 'replay_of_command_id'
+               AND NOT column_row.attisdropped)
+         ];
+
+  IF replay_fk_name IS NOT NULL AND replay_fk_delete_action <> 'n' THEN
+    EXECUTE format(
+      'ALTER TABLE commands DROP CONSTRAINT %I',
+      replay_fk_name
+    );
+    replay_fk_name := NULL;
+  END IF;
+
+  IF replay_fk_name IS NULL THEN
+    ALTER TABLE commands
+      ADD CONSTRAINT commands_replay_of_command_id_fkey
+      FOREIGN KEY (replay_of_command_id)
+      REFERENCES commands(id)
+      ON DELETE SET NULL;
+  END IF;
+END
+$$;

--- a/tests/test_cleanup_agent.py
+++ b/tests/test_cleanup_agent.py
@@ -76,6 +76,71 @@ def test_cleanup_once_deletes_only_old_completed_commands(conn):
     assert recent_done_id in remaining
 
 
+def test_cleanup_expires_original_but_retains_newer_replay(conn):
+    uid_str = str(uuid.uuid4())
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (id, username) VALUES (%s, %s)",
+            (uid_str, "replay-retention-user"),
+        )
+        cur.execute(
+            """
+            INSERT INTO environments (user_id, cwd, env, updated_at)
+            VALUES (%s, '/tmp/stale', '{"stale": true}'::jsonb,
+                    now() - interval '100 days')
+            """,
+            (uid_str,),
+        )
+        cur.execute(
+            """
+            INSERT INTO commands (user_id, command, output, submitted_at, status)
+            VALUES (%s, 'original command', 'original output',
+                    now() - interval '100 days', 'done')
+            RETURNING id
+            """,
+            (uid_str,),
+        )
+        original_id = cur.fetchone()[0]
+        cur.execute(
+            """
+            INSERT INTO commands
+                (user_id, command, output, submitted_at, status,
+                 replay_of_command_id, replay_run_id)
+            VALUES (%s, 'original command', 'replay output', now(), 'done',
+                    %s, %s)
+            RETURNING id
+            """,
+            (uid_str, original_id, str(uuid.uuid4())),
+        )
+        replay_id = cur.fetchone()[0]
+
+    cleanup_once(conn, 90)
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, command, output, replay_of_command_id
+              FROM commands
+             WHERE id IN (%s, %s)
+             ORDER BY id
+            """,
+            (original_id, replay_id),
+        )
+        command_rows = cur.fetchall()
+        cur.execute(
+            "SELECT cwd, env FROM environments WHERE user_id = %s",
+            (uid_str,),
+        )
+        environment = cur.fetchone()
+
+    assert command_rows == [
+        (replay_id, "original command", "replay output", None),
+    ]
+    # The later statement in cleanup_once also completed, proving that the
+    # delete did not trigger a foreign-key error and roll back the transaction.
+    assert environment == ("/home/sandbox", {})
+
+
 def test_cleanup_once_resets_env(conn):
     uid_str = str(uuid.uuid4())
     with conn.cursor() as cur:
@@ -127,4 +192,3 @@ def test_cleanup_once_resets_multiple_envs(conn, caplog):
     for cwd, env in rows:
         assert cwd == '/home/sandbox'
         assert env == {}
-

--- a/workers/cleanup_agent.py
+++ b/workers/cleanup_agent.py
@@ -8,7 +8,12 @@ from workers.db import get_conn
 
 
 def cleanup_once(conn, days: int) -> None:
-    """Remove commands and reset environments older than ``days`` days."""
+    """Remove commands and reset environments older than ``days`` days.
+
+    Replay rows have an independent retention lifetime. Deleting an expired
+    source command clears their ``replay_of_command_id`` through the schema's
+    ``ON DELETE SET NULL`` foreign key, while preserving replay command data.
+    """
     with conn.cursor() as cur:
         cur.execute(
             """


### PR DESCRIPTION
### Motivation
- Define retention semantics so replayed command rows remain available even after their source command ages out, avoiding foreign-key failures during cleanup.
- Provide a safe, idempotent migration path for existing databases to adopt the new delete behavior.

### Description
- Change the commands schema so `replay_of_command_id` uses `ON DELETE SET NULL` in `sql/init_schema.sql` to clear provenance when the original is deleted.
- Add `sql/migrate_replay_provenance_retention.sql`, an idempotent migration that detects and replaces the existing foreign-key behavior with `ON DELETE SET NULL` while tolerating different constraint names.
- Include the migration in `sql/install.sql` so the upgrade runs during installation.
- Update `workers/cleanup_agent.py` docstring to document the intended retention semantics and add an integration test `test_cleanup_expires_original_but_retains_newer_replay` in `tests/test_cleanup_agent.py` that verifies cleanup deletes the original, preserves the replay row, and allows subsequent environment cleanup to complete.

### Testing
- Ran `python -m compileall -q workers tests` which succeeded.
- Ran `pytest -q` and observed `31 passed, 18 skipped`, and the new integration test `test_cleanup_expires_original_but_retains_newer_replay` passed as part of the suite.
- Performed a `git diff --check` to validate formatting and no linter-style diffs were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b85c489248328b24325ae6be2203c)