### PR TITLE
Kill executor subprocess groups on command timeout

### DIFF
--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -1,3 +1,6 @@
+import os
+import time
+
 import pytest
 import workers.executor_agent
 from workers.executor_agent import run_subprocess, handle_command
@@ -36,6 +39,40 @@ def test_run_subprocess_times_out(monkeypatch, tmp_path):
     exit_code, output = run_subprocess("sleep 5", str(tmp_path), None)
     assert exit_code == 124
     assert "Timed out after 1s" in output
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process-group signaling is POSIX-specific")
+def test_run_subprocess_timeout_kills_descendant_with_inherited_pipe(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(workers.executor_agent, "COMMAND_TIMEOUT", 1)
+    pid_file = tmp_path / "descendant.pid"
+    script = (
+        "import pathlib, subprocess, time; "
+        "child = subprocess.Popen(['sleep', '30']); "
+        f"pathlib.Path({str(pid_file)!r}).write_text(str(child.pid)); "
+        "time.sleep(30)"
+    )
+
+    started = time.monotonic()
+    exit_code, output = run_subprocess(
+        f"python3 -c {script!r}", str(tmp_path), None
+    )
+    elapsed = time.monotonic() - started
+
+    assert exit_code == 124
+    assert "Timed out after 1s" in output
+    assert elapsed < 3
+    descendant_pid = int(pid_file.read_text())
+    status_file = f"/proc/{descendant_pid}/status"
+    for _ in range(20):
+        if not os.path.exists(status_file):
+            break
+        if "State:\tZ" in open(status_file).read():
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail(f"descendant process {descendant_pid} is still running")
 
 
 def test_run_subprocess_passes_env_snapshot(monkeypatch, tmp_path):

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -14,6 +14,7 @@ import logging
 import os
 import select
 import shlex
+import signal
 import subprocess
 import time
 from typing import Any, Dict
@@ -31,6 +32,8 @@ COMMAND_TIMEOUT = int(os.getenv("COMMAND_TIMEOUT", "30"))
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 MAX_OUTPUT_BYTES = int(os.getenv("MAX_OUTPUT_BYTES", "65536"))
 TRUNCATION_SUFFIX = "...[truncated]"
+TERMINATION_GRACE_SECONDS = 0.5
+PIPE_DRAIN_TIMEOUT_SECONDS = 0.5
 
 
 def _update_channel_config(conn, channel: str) -> None:
@@ -150,19 +153,51 @@ def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        start_new_session=os.name == "posix",
     )
 
-    deadline = time.time() + COMMAND_TIMEOUT
+    deadline = time.monotonic() + COMMAND_TIMEOUT
     output = bytearray()
     limit_exceeded = False
     timed_out = False
+    termination_deadline = None
+    drain_deadline = None
     fds = [proc.stdout, proc.stderr]
 
     while fds:
-        if time.time() > deadline and not timed_out:
-            proc.kill()
+        now = time.monotonic()
+        if now >= deadline and not timed_out:
+            if os.name == "posix":
+                try:
+                    os.killpg(proc.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+            else:
+                proc.terminate()
             timed_out = True
-        ready, _, _ = select.select(fds, [], [], 0.1)
+            termination_deadline = now + TERMINATION_GRACE_SECONDS
+        elif (
+            termination_deadline is not None
+            and now >= termination_deadline
+            and drain_deadline is None
+        ):
+            if os.name == "posix":
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+            elif proc.poll() is None:
+                proc.kill()
+            drain_deadline = now + PIPE_DRAIN_TIMEOUT_SECONDS
+
+        if drain_deadline is not None and now >= drain_deadline:
+            break
+
+        next_event = deadline if not timed_out else termination_deadline
+        if drain_deadline is not None:
+            next_event = drain_deadline
+        select_timeout = max(0.0, min(0.1, next_event - now))
+        ready, _, _ = select.select(fds, [], [], select_timeout)
         for fd in ready:
             chunk = fd.read1(4096)
             if not chunk:
@@ -178,7 +213,16 @@ def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]
             else:
                 limit_exceeded = True
 
-    proc.wait()
+    for fd in fds:
+        fd.close()
+    if timed_out:
+        try:
+            proc.wait(timeout=TERMINATION_GRACE_SECONDS + PIPE_DRAIN_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+    else:
+        proc.wait()
     exit_code = proc.returncode
     text = output.decode(errors="replace")
     if timed_out:


### PR DESCRIPTION
### Motivation
- Ensure commands started by the executor cannot leave long-running descendants alive when a timeout occurs by targeting the whole process group/session instead of only the immediate child. 
- Prevent the worker from hanging indefinitely due to inherited pipes by bounding pipe draining after termination.

### Description
- Start subprocesses in a new POSIX session with `start_new_session` so descendants form a controllable process group. 
- On timeout use `os.killpg(..., SIGTERM)` then escalate to `SIGKILL` after a bounded grace period configured by `TERMINATION_GRACE_SECONDS`, and use `COMMAND_TIMEOUT` measured with `time.monotonic()` to avoid clock skew. 
- Bound pipe draining with `PIPE_DRAIN_TIMEOUT_SECONDS`, close inherited file descriptors, and ensure `proc.wait()` is bounded and falls back to `proc.kill()` if needed. 
- Add a POSIX-only regression test `test_run_subprocess_timeout_kills_descendant_with_inherited_pipe` that spawns a long-lived descendant inheriting stdout/stderr and verifies the executor returns quickly with exit code `124` and no leftover descendant.

### Testing
- Ran `pytest -q tests/test_executor_agent.py` and the test suite for that file passed (`15 passed`).
- Ran the full test suite (`pytest -q`) and it passed (`35 passed, 19 skipped`).
- Verified repository checks (`git diff --check`) produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b8851c0888328885425a3ed0f8e06)