### PR TITLE
Harden executor command policy and process isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,34 @@ Set `COMMAND_TIMEOUT` (seconds) to limit how long each command may run.
 Commands are parsed with `shlex.split` before execution, so quoting rules follow
 POSIX shells but features like glob expansion are not performed.
 
+### Executor command and isolation policy
+
+The executor does **not** provide an unrestricted shell. `ALLOWED_EXECUTABLES`
+is a comma-separated allowlist of executable names (not paths); it defaults to
+`cat,echo,false,head,ls,printf,pwd,python3,sleep,tail,true,wc`. Commands using an
+unsupported name, an absolute/relative executable path, or an explicit resource
+path outside `SHELL_ROOT` are rejected before process creation and recorded as
+`failed` with exit code 126. `EXECUTOR_PATH` (default `/usr/bin:/bin`) is trusted
+administrator configuration and cannot be overridden by a stored environment
+snapshot. `cd` is the only built-in and is confined to `SHELL_ROOT`.
+
+Each child receives address-space and process-count limits, configurable with
+`COMMAND_MEMORY_BYTES` (default 256 MiB) and `COMMAND_MAX_PROCESSES` (default
+32). In production, set `EXECUTOR_UID` and `EXECUTOR_GID` to a dedicated,
+unprivileged OS account; UID 0 is refused. `EXECUTOR_CHROOT` optionally enters a
+prepared chroot containing the allowlisted binaries and their libraries before
+dropping privileges.
+
+The allowlist and argument checks are defense in depth, **not a complete
+sandbox**: an allowed program (especially an interpreter) can access paths that
+do not appear as plain command arguments. Deploy the worker in a dedicated
+container or VM with a read-only root filesystem, only `SHELL_ROOT` mounted
+writable, no host mounts or credentials, no-new-privileges/capabilities dropped,
+seccomp syscall filtering, cgroup CPU/memory/PID limits, and network access
+denied unless explicitly required. For stronger local isolation, populate and
+enable `EXECUTOR_CHROOT`; container/VM isolation is still required for hostile
+multi-tenant workloads.
+
 You can run `cleanup_agent.py` periodically and use `replay_agent.py` for
 
 session replays. The optional `monitor_agent.py` emits usage metrics like

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -216,7 +216,7 @@ def test_handle_command_cd_absolute_outside_root_fails(tmp_path, monkeypatch):
     assert 'Permission denied' in captured['output']
 
 
-def test_handle_command_cd_with_extra_args_runs_subprocess(monkeypatch):
+def test_handle_command_cd_with_extra_args_is_rejected(monkeypatch):
     captured: dict = {}
 
     def fake_run_subprocess(command, cwd, env):
@@ -245,9 +245,10 @@ def test_handle_command_cd_with_extra_args_runs_subprocess(monkeypatch):
 
     handle_command(None, row)
 
-    assert captured['command'] == 'cd /tmp extra'
-    assert captured['status'] == 'done'
-    assert captured['exit_code'] == 0
+    assert 'command' not in captured
+    assert captured['status'] == 'failed'
+    assert captured['exit_code'] == 126
+    assert 'unsupported executable' in captured['output']
 
 
 def test_handle_command_malformed_command(monkeypatch):
@@ -304,8 +305,53 @@ def test_handle_command_missing_binary_marks_failed(monkeypatch, tmp_path):
     handle_command(None, row)
 
     assert captured['status'] == 'failed'
-    assert captured['exit_code'] == 1
-    assert 'No such file or directory' in captured['output']
+    assert captured['exit_code'] == 126
+    assert 'Command rejected by executor policy' in captured['output']
+
+
+def test_allowed_command_is_started(monkeypatch, tmp_path):
+    monkeypatch.setenv('ALLOWED_EXECUTABLES', 'echo')
+    exit_code, output = run_subprocess('echo allowed', str(tmp_path), None)
+    assert exit_code == 0
+    assert output == 'allowed\n'
+
+
+@pytest.mark.parametrize('command', ['uname', '/bin/echo bypass', './echo bypass'])
+def test_disallowed_executable_and_path_bypasses_are_rejected(
+    monkeypatch, tmp_path, command
+):
+    monkeypatch.setenv('ALLOWED_EXECUTABLES', 'echo')
+    with pytest.raises(workers.executor_agent.UnsupportedCommand):
+        run_subprocess(command, str(tmp_path), None)
+
+
+def test_resource_outside_shell_root_is_rejected(monkeypatch, tmp_path):
+    monkeypatch.setenv('ALLOWED_EXECUTABLES', 'cat')
+    monkeypatch.setenv('SHELL_ROOT', str(tmp_path))
+    with pytest.raises(workers.executor_agent.UnsupportedCommand) as exc:
+        run_subprocess('cat /etc/passwd', str(tmp_path), None)
+    assert 'outside SHELL_ROOT' in str(exc.value)
+
+
+def test_handle_command_records_policy_rejection(monkeypatch, tmp_path):
+    captured = {}
+    monkeypatch.setenv('ALLOWED_EXECUTABLES', 'echo')
+    monkeypatch.setattr(
+        workers.executor_agent,
+        'update_command',
+        lambda conn, cmd_id, status, output, exit_code: captured.update(
+            status=status, output=output, exit_code=exit_code
+        ),
+    )
+    handle_command(None, {
+        'id': 8, 'user_id': 'u1', 'command': 'uname -a',
+        'cwd_snapshot': str(tmp_path), 'env_snapshot': None,
+    })
+    assert captured == {
+        'status': 'failed',
+        'output': 'Command rejected by executor policy: unsupported executable.',
+        'exit_code': 126,
+    }
 
 
 def test_main_closes_connection_on_keyboard_interrupt(monkeypatch):

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -12,6 +12,7 @@ script.
 import json
 import logging
 import os
+import resource
 import select
 import shlex
 import subprocess
@@ -31,6 +32,80 @@ COMMAND_TIMEOUT = int(os.getenv("COMMAND_TIMEOUT", "30"))
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 MAX_OUTPUT_BYTES = int(os.getenv("MAX_OUTPUT_BYTES", "65536"))
 TRUNCATION_SUFFIX = "...[truncated]"
+
+# Commands are executed directly (never through a shell).  Allowlist entries are
+# executable *names*, rather than paths, so `/tmp/ls` cannot masquerade as `ls`.
+# This is a policy boundary, not a replacement for the deployment sandbox; see
+# README.md for the required container/filesystem isolation.
+DEFAULT_ALLOWED_EXECUTABLES = "cat,echo,false,head,ls,printf,pwd,python3,sleep,tail,true,wc"
+REJECTED_COMMAND_MESSAGE = "Command rejected by executor policy"
+
+
+class UnsupportedCommand(ValueError):
+    """Raised before process creation when a command violates policy."""
+
+
+def _allowed_executables() -> set[str]:
+    configured = os.getenv("ALLOWED_EXECUTABLES", DEFAULT_ALLOWED_EXECUTABLES)
+    return {name.strip() for name in configured.split(",") if name.strip()}
+
+
+def validate_command(tokens: list[str], cwd: str) -> None:
+    if not tokens:
+        raise UnsupportedCommand("empty command")
+    executable = tokens[0]
+    if (
+        os.path.basename(executable) != executable
+        or executable not in _allowed_executables()
+    ):
+        raise UnsupportedCommand("unsupported executable")
+
+    # Reject explicit references outside SHELL_ROOT.  This catches common path
+    # traversal mistakes; the OS sandbox remains responsible for indirect access
+    # performed by an allowed interpreter or executable.
+    shell_root_value = os.getenv("SHELL_ROOT")
+    if not shell_root_value:
+        return
+    shell_root = os.path.realpath(shell_root_value)
+    real_cwd = os.path.realpath(cwd)
+    try:
+        if os.path.commonpath([shell_root, real_cwd]) != shell_root:
+            raise UnsupportedCommand("working directory is outside SHELL_ROOT")
+    except ValueError as exc:
+        raise UnsupportedCommand("working directory is outside SHELL_ROOT") from exc
+    for argument in tokens[1:]:
+        if not (argument.startswith("/") or argument == ".." or argument.startswith("../")):
+            continue
+        candidate = os.path.realpath(
+            argument if os.path.isabs(argument) else os.path.join(real_cwd, argument)
+        )
+        try:
+            permitted = os.path.commonpath([shell_root, candidate]) == shell_root
+        except ValueError:
+            permitted = False
+        if not permitted:
+            raise UnsupportedCommand("resource path is outside SHELL_ROOT")
+
+
+def _sandbox_identity_and_limits() -> None:
+    """Apply per-process identity, resource, and optional chroot controls."""
+    chroot = os.getenv("EXECUTOR_CHROOT")
+    if chroot:
+        os.chroot(chroot)
+        os.chdir("/")
+    gid = os.getenv("EXECUTOR_GID")
+    uid = os.getenv("EXECUTOR_UID")
+    if gid:
+        os.setgroups([])
+        os.setgid(int(gid))
+    if uid:
+        if int(uid) == 0:
+            raise RuntimeError("EXECUTOR_UID must not be root")
+        os.setuid(int(uid))
+    memory = int(os.getenv("COMMAND_MEMORY_BYTES", "268435456"))
+    processes = int(os.getenv("COMMAND_MAX_PROCESSES", "32"))
+    resource.setrlimit(resource.RLIMIT_AS, (memory, memory))
+    resource.setrlimit(resource.RLIMIT_NPROC, (processes, processes))
 
 
 def _update_channel_config(conn, channel: str) -> None:
@@ -142,14 +217,21 @@ def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]
             env.update(json.loads(env_snapshot))
         else:
             env.update(env_snapshot)
+    # Resolution of an allowed name must use an administrator-controlled path;
+    # user snapshots must not redirect it to a lookalike executable.
+    env["PATH"] = os.getenv("EXECUTOR_PATH", "/usr/bin:/bin")
+    for unsafe_name in ("LD_PRELOAD", "LD_LIBRARY_PATH", "PYTHONPATH", "PYTHONHOME"):
+        env.pop(unsafe_name, None)
 
     cmd_list = shlex.split(command)
+    validate_command(cmd_list, cwd)
     proc = subprocess.Popen(
         cmd_list,
         cwd=cwd,
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        preexec_fn=_sandbox_identity_and_limits,
     )
 
     deadline = time.time() + COMMAND_TIMEOUT
@@ -208,6 +290,15 @@ def handle_command(conn, row: Dict[str, Any]) -> None:
         )
         update_command(conn, row["id"], "failed", str(exc), 1)
         return
+
+    if not (len(tokens) == 2 and tokens[0] == "cd"):
+        try:
+            validate_command(tokens, row["cwd_snapshot"])
+        except UnsupportedCommand as exc:
+            explanation = f"{REJECTED_COMMAND_MESSAGE}: {exc}."
+            logging.warning("Rejected command %s: %s", row["id"], exc)
+            update_command(conn, row["id"], "failed", explanation, 126)
+            return
 
     if len(tokens) == 2 and tokens[0] == "cd":
         path = tokens[1]


### PR DESCRIPTION
### Motivation

- Prevent execution of arbitrary binaries or path-based bypasses by validating commands before process creation.  
- Reduce risk of privilege/environment injection by using a trusted `PATH` and scrubbing unsafe loader/interpreter environment variables.  
- Provide deployers with documented runtime controls (chroot, UID/GID, rlimits) and explicit guidance that allowlist checks are defense-in-depth, not a full sandbox.  

### Description

- Add a configurable allowlist with name-based validation via `ALLOWED_EXECUTABLES` and a `validate_command` helper that rejects absolute/relative executable paths and argument paths outside `SHELL_ROOT`. (updated `workers/executor_agent.py`).  
- Implement pre-execution policy rejection that records rejected commands as `failed` with a safe, user-visible explanation and exit code `126` (updated `handle_command` and `run_subprocess` behavior in `workers/executor_agent.py`).  
- Enforce a trusted search path and scrub unsafe env vars (`LD_PRELOAD`, `LD_LIBRARY_PATH`, `PYTHONPATH`, `PYTHONHOME`) before launching, and add optional per-process hardening via `EXECUTOR_CHROOT`, `EXECUTOR_UID`, `EXECUTOR_GID`, and rlimits for memory/process count (updated `workers/executor_agent.py`).  
- Add tests for allowed commands, disallowed executables and path-bypass attempts, resource access outside `SHELL_ROOT`, and that policy rejections are recorded; update `tests/test_executor_agent.py`.  
- Document the policy, configuration keys, and required deployment isolation (container/VM, seccomp/cgroups, read-only root, etc.) in `README.md`.  

### Testing

- Ran unit tests for the executor: `python -m pytest tests/test_executor_agent.py -q` and all tests in that file passed (`20 passed`).  
- Ran full test suite: `python -m pytest -q` which completed with `40 passed, 19 skipped`.  
- Ran bytecode checks with `python -m compileall -q workers tests` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b885b0df883289bceace79b193684)