### PR TITLE
Cleanup: delete expired failed commands, retain active work

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ Set `COMMAND_TIMEOUT` (seconds) to limit how long each command may run.
 Commands are parsed with `shlex.split` before execution, so quoting rules follow
 POSIX shells but features like glob expansion are not performed.
 
-You can run `cleanup_agent.py` periodically and use `replay_agent.py` for
-
-session replays. The optional `monitor_agent.py` emits usage metrics like
+You can run `cleanup_agent.py` periodically. Command retention applies only to
+terminal statuses: `done` and `failed` commands older than `CLEANUP_DAYS` are
+deleted, while recent terminal commands and all `pending` or `running` commands
+are retained. Use `replay_agent.py` for session replays. The optional
+`monitor_agent.py` emits usage metrics like
 command counts and average run time to stdout or CSV.
 
 ## Serving the HTML UI

--- a/tests/test_cleanup_agent.py
+++ b/tests/test_cleanup_agent.py
@@ -35,7 +35,7 @@ def conn():
     conn.close()
 
 
-def test_cleanup_once_deletes_only_old_completed_commands(conn):
+def test_cleanup_once_deletes_only_old_terminal_commands(conn):
     uid_str = str(uuid.uuid4())
     with conn.cursor() as cur:
         cur.execute(
@@ -48,20 +48,41 @@ def test_cleanup_once_deletes_only_old_completed_commands(conn):
             (uid_str,),
         )
         old_done_id = cur.fetchone()[0]
-        # Old but not done -> preserved (cleanup only targets completed history)
+        # Old + failed -> deleted
         cur.execute(
             "INSERT INTO commands (user_id, command, submitted_at, status) "
             "VALUES (%s, 'old-failed', now() - interval '100 days', 'failed') RETURNING id",
             (uid_str,),
         )
         old_failed_id = cur.fetchone()[0]
-        # Recent + done -> preserved (still within retention window)
+        # Recent terminal commands -> preserved (still within retention window)
         cur.execute(
             "INSERT INTO commands (user_id, command, submitted_at, status) "
             "VALUES (%s, 'recent-done', now(), 'done') RETURNING id",
             (uid_str,),
         )
         recent_done_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO commands (user_id, command, submitted_at, status) "
+            "VALUES (%s, 'recent-failed', now(), 'failed') RETURNING id",
+            (uid_str,),
+        )
+        recent_failed_id = cur.fetchone()[0]
+        # Non-terminal commands are preserved regardless of age
+        cur.execute(
+            "INSERT INTO commands (user_id, command, submitted_at, status) "
+            "VALUES (%s, 'old-pending', now() - interval '100 days', 'pending') "
+            "RETURNING id",
+            (uid_str,),
+        )
+        old_pending_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO commands (user_id, command, submitted_at, status) "
+            "VALUES (%s, 'old-running', now() - interval '100 days', 'running') "
+            "RETURNING id",
+            (uid_str,),
+        )
+        old_running_id = cur.fetchone()[0]
 
     cleanup_once(conn, 90)
 
@@ -72,8 +93,11 @@ def test_cleanup_once_deletes_only_old_completed_commands(conn):
         remaining = [row[0] for row in cur.fetchall()]
 
     assert old_done_id not in remaining
-    assert old_failed_id in remaining
+    assert old_failed_id not in remaining
     assert recent_done_id in remaining
+    assert recent_failed_id in remaining
+    assert old_pending_id in remaining
+    assert old_running_id in remaining
 
 
 def test_cleanup_expires_original_but_retains_newer_replay(conn):

--- a/workers/cleanup_agent.py
+++ b/workers/cleanup_agent.py
@@ -18,7 +18,7 @@ def cleanup_once(conn, days: int) -> None:
         cur.execute(
             """
             DELETE FROM commands
-             WHERE status = 'done'
+             WHERE status IN ('done', 'failed')
                AND submitted_at < now() - %s * interval '1 day'
             RETURNING id
             """,


### PR DESCRIPTION
### Motivation

- Ensure the cleanup agent removes all expired terminal commands, not just `done` rows, so that old failed commands do not accumulate. 
- Preserve in-progress work by explicitly retaining `pending` and `running` commands regardless of age. 
- Make retention semantics explicit in the docs so operators know which statuses are subject to deletion.

### Description

- Modify `cleanup_once` in `workers/cleanup_agent.py` to delete commands where `status IN ('done', 'failed')` and older than the retention window. 
- Extend `tests/test_cleanup_agent.py` to assert that old `failed` commands are deleted, recent `failed` commands are retained, and old `pending`/`running` commands are preserved. 
- Update `README.md` to state that only terminal statuses (`done`, `failed`) older than `CLEANUP_DAYS` are deleted while `pending` and `running` are retained. 

### Testing

- Ran `python -m pytest` and observed `34 passed, 19 skipped` due to integration tests requiring external services. 
- Ran `python -m pytest tests/test_cleanup_agent.py` which skipped the DB-backed tests when `TEST_DATABASE_URL` was not set. 
- Ran `python -m compileall -q workers tests` to verify files compile with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b885ef6fc83288e753734f49b7adf)