### PR TITLE
Validate cleanup agent retention settings

### DIFF
--- a/tests/test_cleanup_agent.py
+++ b/tests/test_cleanup_agent.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import uuid
 import logging
 from pathlib import Path
@@ -6,11 +7,84 @@ from pathlib import Path
 import psycopg2
 import pytest
 
+from workers import cleanup_agent
 from workers.cleanup_agent import cleanup_once
-
 
 INIT_SQL = Path("sql/init_schema.sql").read_text()
 
+
+@pytest.mark.parametrize("days", ["0", "-1"])
+def test_main_rejects_non_positive_days_before_connecting(days, monkeypatch, capsys):
+    monkeypatch.setattr(
+        cleanup_agent,
+        "get_conn",
+        lambda: pytest.fail("database connection should not be opened"),
+    )
+    monkeypatch.setattr(sys, "argv", ["cleanup_agent.py", "--days", days, "--once"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        cleanup_agent.main()
+
+    assert exc_info.value.code == 2
+    assert "--days must be a positive integer" in capsys.readouterr().err
+
+
+def test_main_rejects_malformed_cleanup_days_before_connecting(monkeypatch, capsys):
+    monkeypatch.setattr(
+        cleanup_agent,
+        "get_conn",
+        lambda: pytest.fail("database connection should not be opened"),
+    )
+    monkeypatch.setattr(sys, "argv", ["cleanup_agent.py", "--once"])
+    monkeypatch.setenv("CLEANUP_DAYS", "not-a-number")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cleanup_agent.main()
+
+    assert exc_info.value.code == 2
+    assert (
+        "CLEANUP_DAYS must be an integer (got 'not-a-number')"
+        in capsys.readouterr().err
+    )
+
+
+@pytest.mark.parametrize("days", ["0", "-1"])
+def test_main_rejects_non_positive_cleanup_days_environment_default(
+    days, monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        cleanup_agent,
+        "get_conn",
+        lambda: pytest.fail("database connection should not be opened"),
+    )
+    monkeypatch.setattr(sys, "argv", ["cleanup_agent.py", "--once"])
+    monkeypatch.setenv("CLEANUP_DAYS", days)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cleanup_agent.main()
+
+    assert exc_info.value.code == 2
+    assert "--days must be a positive integer" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("interval", ["0", "-1"])
+def test_main_rejects_non_positive_intervals_before_connecting(
+    interval, monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        cleanup_agent,
+        "get_conn",
+        lambda: pytest.fail("database connection should not be opened"),
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["cleanup_agent.py", "--interval", interval, "--once"]
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cleanup_agent.main()
+
+    assert exc_info.value.code == 2
+    assert "--interval must be a positive integer" in capsys.readouterr().err
 
 
 @pytest.fixture(scope="module")
@@ -28,9 +102,7 @@ def conn():
     cur.close()
     yield conn
     cur = conn.cursor()
-    cur.execute(
-        "DROP TABLE commands, environments, users, pg_shell_config CASCADE;"
-    )
+    cur.execute("DROP TABLE commands, environments, users, pg_shell_config CASCADE;")
     cur.close()
     conn.close()
 
@@ -144,10 +216,12 @@ def test_cleanup_expires_original_but_retains_newer_replay(conn):
 def test_cleanup_once_resets_env(conn):
     uid_str = str(uuid.uuid4())
     with conn.cursor() as cur:
-        cur.execute("INSERT INTO users (id, username) VALUES (%s, %s)", (uid_str, "testuser"))
+        cur.execute(
+            "INSERT INTO users (id, username) VALUES (%s, %s)", (uid_str, "testuser")
+        )
         cur.execute(
             "INSERT INTO environments (user_id, cwd, env, updated_at) VALUES (%s, %s, %s::jsonb, now() - interval '100 days')",
-            (uid_str, '/tmp', '{"k":1}'),
+            (uid_str, "/tmp", '{"k":1}'),
         )
         cur.execute(
             "INSERT INTO commands (user_id, command, submitted_at, status) VALUES (%s, 'ls', now() - interval '100 days', 'done')",
@@ -160,7 +234,7 @@ def test_cleanup_once_resets_env(conn):
         cur.execute("SELECT cwd, env FROM environments WHERE user_id = %s", (uid_str,))
         cwd, env = cur.fetchone()
 
-    assert cwd == '/home/sandbox'
+    assert cwd == "/home/sandbox"
     assert env == {}
 
 
@@ -174,11 +248,11 @@ def test_cleanup_once_resets_multiple_envs(conn, caplog):
             )
             cur.execute(
                 "INSERT INTO environments (user_id, cwd, env, updated_at) VALUES (%s, %s, %s::jsonb, now() - interval '100 days')",
-                (uid, '/tmp', '{"k":1}')
+                (uid, "/tmp", '{"k":1}'),
             )
             cur.execute(
                 "INSERT INTO commands (user_id, command, submitted_at, status) VALUES (%s, 'ls', now() - interval '100 days', 'done')",
-                (uid,)
+                (uid,),
             )
     caplog.set_level(logging.INFO)
     cleanup_once(conn, 90)
@@ -186,9 +260,9 @@ def test_cleanup_once_resets_multiple_envs(conn, caplog):
     with conn.cursor() as cur:
         cur.execute(
             "SELECT cwd, env FROM environments WHERE user_id = ANY(%s::uuid[]) ORDER BY user_id",
-            (ids,)
+            (ids,),
         )
         rows = cur.fetchall()
     for cwd, env in rows:
-        assert cwd == '/home/sandbox'
+        assert cwd == "/home/sandbox"
         assert env == {}

--- a/workers/cleanup_agent.py
+++ b/workers/cleanup_agent.py
@@ -41,21 +41,36 @@ def cleanup_once(conn, days: int) -> None:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Cleanup old commands and environments")
-    parser.add_argument(
-        "--interval", type=int, default=3600,
-        help="Seconds between cleanup runs (default: 3600)"
+    parser = argparse.ArgumentParser(
+        description="Cleanup old commands and environments"
     )
     parser.add_argument(
-        "--once", action="store_true", help="Run cleanup once and exit"
+        "--interval",
+        type=int,
+        default=3600,
+        help="Seconds between cleanup runs (default: 3600)",
     )
+    parser.add_argument("--once", action="store_true", help="Run cleanup once and exit")
     parser.add_argument(
         "--days",
         type=int,
-        default=int(os.getenv("CLEANUP_DAYS", "90")),
+        default=None,
         help="Age threshold in days (default: 90)",
     )
     args = parser.parse_args()
+
+    if args.days is None:
+        cleanup_days = os.getenv("CLEANUP_DAYS", "90")
+        try:
+            args.days = int(cleanup_days)
+        except ValueError:
+            parser.error(f"CLEANUP_DAYS must be an integer (got {cleanup_days!r})")
+
+    if args.days <= 0:
+        parser.error("--days must be a positive integer")
+    if args.interval <= 0:
+        parser.error("--interval must be a positive integer")
+
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
     while True:


### PR DESCRIPTION
### Motivation

- Prevent the cleanup agent from opening a database connection or mutating data when given invalid retention or interval values.
- Ensure malformed `CLEANUP_DAYS` environment defaults are reported clearly through `argparse` so execution stops early.

### Description

- Change `--days` default handling in `workers/cleanup_agent.py` to defer to `CLEANUP_DAYS` and parse it with an explicit `int()` conversion that reports non-integer values via `parser.error`.
- Validate that `args.days` and `args.interval` are strictly positive and call `parser.error` for zero or negative values so the process exits before attempting `get_conn()` or other work.
- Keep the existing `cleanup_once` implementation unchanged and only enforce argument/env validation in `main()`.
- Add unit tests in `tests/test_cleanup_agent.py` that exercise zero, negative, and malformed retention values and zero/negative intervals while asserting no DB connection is opened for invalid inputs.

### Testing

- Ran the test suite with `pytest -q`, resulting in `41 passed, 19 skipped`.
- Ran style and static checks with `ruff` and `black --check`, both passing after formatting the changed files with `black`.
- Verified `parser.error` behavior by asserting `SystemExit` with code `2` and checking stderr in the new tests.
- Tests covering `cleanup_once` and the added argument validation all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b8861081c8328a81740b2f1581d07)