### PR TITLE
Return meaningful replay agent exit statuses

### DIFF
--- a/tests/test_replay_agent.py
+++ b/tests/test_replay_agent.py
@@ -1,6 +1,8 @@
 import logging
 import math
+import sys
 
+import psycopg2
 import workers.replay_agent as replay_agent
 
 
@@ -103,6 +105,53 @@ class FakeConnFactory:
         if not self._connections:
             raise AssertionError("get_conn called more times than expected")
         return self._connections.pop(0)
+
+
+def test_main_returns_zero_after_successful_replay(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["replay_agent.py", "--user", "u1", "--start", "1"])
+    monkeypatch.setattr(replay_agent, "replay_commands", lambda *args, **kwargs: None)
+
+    assert replay_agent.main() == 0
+
+
+def test_main_returns_nonzero_for_invalid_option(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "replay_agent.py",
+            "--user",
+            "u1",
+            "--start",
+            "1",
+            "--resume",
+            "--force",
+        ],
+    )
+
+    assert replay_agent.main() != 0
+
+
+def test_main_returns_nonzero_for_connection_failure(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["replay_agent.py", "--user", "u1", "--start", "1"])
+
+    def fail_to_connect(*args, **kwargs):
+        raise RuntimeError("connection unavailable")
+
+    monkeypatch.setattr(replay_agent, "replay_commands", fail_to_connect)
+
+    assert replay_agent.main() != 0
+
+
+def test_main_returns_nonzero_for_database_operation_failure(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["replay_agent.py", "--user", "u1", "--start", "1"])
+
+    def fail_database_operation(*args, **kwargs):
+        raise psycopg2.DatabaseError("query failed")
+
+    monkeypatch.setattr(replay_agent, "replay_commands", fail_database_operation)
+
+    assert replay_agent.main() != 0
 
 
 def test_replay_commands_no_commands_logs_message(monkeypatch, caplog):

--- a/workers/replay_agent.py
+++ b/workers/replay_agent.py
@@ -86,7 +86,7 @@ def replay_commands(
                 logging.info("Skipped %d commands already replayed", skipped)
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser(description="Replay user commands")
     parser.add_argument("--user", required=True, help="User ID")
     parser.add_argument(
@@ -108,9 +108,12 @@ def main() -> None:
         default=100,
         help="Commit after this many submitted replay rows",
     )
-    args = parser.parse_args()
-    if args.commit_every <= 0:
-        parser.error("--commit-every must be greater than zero")
+    try:
+        args = parser.parse_args()
+        if args.commit_every <= 0:
+            parser.error("--commit-every must be greater than zero")
+    except SystemExit as exc:
+        return int(exc.code or 0)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
     try:
         replay_commands(
@@ -122,9 +125,15 @@ def main() -> None:
         )
     except ValueError as exc:
         logging.error("Replay agent argument error: %s", exc)
+        return 1
     except RuntimeError as exc:
         logging.error("Replay agent failed to connect to database: %s", exc)
+        return 1
+    except Exception:
+        logging.exception("Replay agent failed during database operation")
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Ensure the `replay_agent` process returns an integer exit status so callers can detect success or failure programmatically. 
- Surface invalid-argument, connection, and database-operation failures as nonzero statuses instead of silently logging them. 
- Preserve `argparse` semantics so argparse-driven exits still produce their intended exit codes. 

### Description
- Change `workers/replay_agent.py::main` to return an `int` and return nonzero for `ValueError`, `RuntimeError` (DB connection failures), and other operational exceptions. 
- Catch `SystemExit` from `parser.parse_args()` and return the original argparse exit code. 
- Invoke the script entrypoint with `raise SystemExit(main())` to translate the returned integer into a process exit. 
- Add tests in `tests/test_replay_agent.py` that assert exit codes for successful runs, invalid/conflicting options, connection failures, and database-operation failures. 

### Testing
- Ran `pytest -q` and the test suite completed successfully with `46 passed, 19 skipped`. 
- Ran `ruff` on the modified files (`workers/replay_agent.py` and `tests/test_replay_agent.py`) and the checks passed for those changes. 
- Ran `git diff --check` and no new whitespace or diff issues were introduced. 
- Note: a repository-wide `ruff check .` still reports pre-existing `E402` violations in `workers/monitor_agent.py`, which are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b8ae7b05483289e38ff2cf9710104)