### PR TITLE
Serialize per-user command execution and resolve runtime state

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -74,8 +74,13 @@ CREATE INDEX commands_user_id_id_idx ON commands (user_id, id);
 
 Execution must:
 
-- chdir to cwd_snapshot
-- set ENV from env_snapshot
+- serialize execution per user with a database-backed claim while still
+  allowing different users to execute concurrently
+- resolve the effective `cwd` and ENV from `environments` when the command is
+  claimed, after every earlier command for that user has completed, and store
+  those values in `cwd_snapshot` and `env_snapshot`
+- chdir to the resolved cwd snapshot
+- set ENV from the resolved env snapshot
 - run command via `execve()`
 - capture stdout, stderr, and exit status
 - update `commands` row and optionally modify `environments` (e.g., cd path)
@@ -123,6 +128,10 @@ Requests/responses in JSON.
 
 - `commands` table is full audit log
 - Session replay: pull all commands ≥ session start, apply in order
+- Replay uses **sequential replay state**, not the original commands'
+  historical snapshots: the first replay command starts from the user's
+  effective environment when claimed, and each later replay command observes
+  successful state changes made by earlier commands in that replay
 - Use `fork_session()` to snapshot state and replay from that point
 
 ---

--- a/tests/test_executor_integration.py
+++ b/tests/test_executor_integration.py
@@ -8,6 +8,8 @@ the unit tests in ``test_executor_agent.py`` stub out. They require
 
 import uuid
 
+import psycopg2
+
 from workers.executor_agent import fetch_pending, handle_command
 
 
@@ -86,3 +88,42 @@ def test_fetch_pending_returns_none_when_idle(db_conn):
         assert fetch_pending(db_conn) is None
     finally:
         db_conn.autocommit = True
+
+
+def test_queued_commands_use_sequential_per_user_environment(
+    db_conn, monkeypatch, tmp_path
+):
+    """A second worker cannot overtake cd or use its submission snapshot."""
+    child = tmp_path / "child"
+    child.mkdir()
+    monkeypatch.setenv("SHELL_ROOT", str(tmp_path))
+    user_id = _create_user_with_env(db_conn, str(tmp_path))
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT submit_command(%s, %s)", (user_id, "cd child"))
+        cd_id = cur.fetchone()[0]
+        cur.execute("SELECT submit_command(%s, %s)", (user_id, "pwd"))
+        pwd_id = cur.fetchone()[0]
+
+    worker_one = psycopg2.connect(db_conn.dsn)
+    worker_two = psycopg2.connect(db_conn.dsn)
+    try:
+        first = fetch_pending(worker_one)
+        assert first["id"] == cd_id
+
+        # This worker is eligible, but cannot claim the same user's later row.
+        assert fetch_pending(worker_two) is None
+        handle_command(worker_one, first)
+
+        second = fetch_pending(worker_two)
+        assert second["id"] == pwd_id
+        assert second["cwd_snapshot"] == str(child)
+        handle_command(worker_two, second)
+    finally:
+        worker_one.close()
+        worker_two.close()
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT status, output FROM commands WHERE id = %s", (pwd_id,))
+        status, output = cur.fetchone()
+    assert status == "done"
+    assert output.strip() == str(child)

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -100,21 +100,50 @@ def wait_for_notify(conn, timeout: float) -> None:
 
 
 def fetch_pending(conn) -> Dict[str, Any] | None:
+    """Claim the next command while holding a session-level per-user lock.
+
+    The advisory lock remains held after this function commits and is released
+    by :func:`handle_command`.  Consequently another executor connection cannot
+    run a command for the same user concurrently.  Snapshots are refreshed from
+    the user's effective environment at claim time, after all preceding
+    commands have reached a terminal state.
+    """
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute("BEGIN;")
-        cur.execute(
-            """
-            SELECT id, user_id, command, cwd_snapshot, env_snapshot
-            FROM commands
-            WHERE status = 'pending'
-            ORDER BY submitted_at
+        cur.execute("""
+            SELECT c.id, c.user_id, c.command, e.cwd, e.env,
+                   hashtextextended(c.user_id::text, 0) AS claim_lock_key
+            FROM commands AS c
+            JOIN environments AS e ON e.user_id = c.user_id
+            WHERE c.status = 'pending'
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM commands AS earlier
+                    WHERE earlier.user_id = c.user_id
+                      AND earlier.status IN ('pending', 'running')
+                      AND (earlier.submitted_at, earlier.id)
+                          < (c.submitted_at, c.id)
+              )
+            ORDER BY c.submitted_at, c.id
             FOR UPDATE SKIP LOCKED
             LIMIT 1
-            """
-        )
+            """)
         row = cur.fetchone()
         if row:
-            cur.execute("UPDATE commands SET status='running' WHERE id=%s", (row["id"],))
+            cur.execute("SELECT pg_try_advisory_lock(%s)", (row["claim_lock_key"],))
+            if not cur.fetchone()[0]:
+                conn.commit()
+                return None
+            cur.execute(
+                """
+                UPDATE commands
+                   SET status = 'running', cwd_snapshot = %s, env_snapshot = %s
+                 WHERE id = %s
+                """,
+                (row["cwd"], row["env"], row["id"]),
+            )
+            row["cwd_snapshot"] = row.pop("cwd")
+            row["env_snapshot"] = row.pop("env")
             logging.info("Fetched command %s for user %s", row["id"], row["user_id"])
         conn.commit()
         return row
@@ -233,7 +262,27 @@ def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]
     return exit_code, text
 
 
+def _release_user_claim(conn, row: Dict[str, Any]) -> None:
+    lock_key = row.get("claim_lock_key")
+    if lock_key is None:
+        return
+    # A command-side database error may have left the transaction aborted;
+    # advisory unlock must still be allowed to run before this worker polls.
+    conn.rollback()
+    with conn.cursor() as cur:
+        cur.execute("SELECT pg_advisory_unlock(%s)", (lock_key,))
+    conn.commit()
+
+
 def handle_command(conn, row: Dict[str, Any]) -> None:
+    """Execute a claimed command and always release its per-user claim."""
+    try:
+        _handle_command(conn, row)
+    finally:
+        _release_user_claim(conn, row)
+
+
+def _handle_command(conn, row: Dict[str, Any]) -> None:
     command = row["command"].strip()
     logging.info(
         "Executing command %s for user %s: %s",


### PR DESCRIPTION
### Motivation

- Prevent multiple executor workers from concurrently claiming and running commands for the same user, preserving per-user command ordering.
- Ensure the effective environment (cwd and env) used for execution is resolved at claim time after all earlier commands for that user have completed.
- Make replay semantics deterministic by clarifying that replay applies sequential-state semantics rather than blindly using historical snapshots.

### Description

- Updated `workers/executor_agent.py::fetch_pending` to only consider the earliest pending command per user, join the `environments` row to refresh `cwd`/`env` at claim time, compute a per-user advisory lock key, and attempt `pg_try_advisory_lock` before claiming a command.
- When a claim succeeds the code updates the command to `running` and stores the refreshed `cwd_snapshot` and `env_snapshot`, and returns the claimed row; if the lock attempt fails the function returns `None` so another worker can try a different row.
- Added `_release_user_claim` and refactored `handle_command` to always release the per-user advisory lock (running a `conn.rollback()` first to ensure the unlock can succeed after an aborted transaction) and moved the original command execution into `_handle_command` to guarantee unlock on all paths.
- Added `tests/test_executor_integration.py::test_queued_commands_use_sequential_per_user_environment` which spins up two DB connections to emulate two workers, queues `cd child` then `pwd`, verifies the second worker cannot overtake the first, and asserts `pwd` sees the updated child cwd.
- Documented the change in `SPEC.md` to require database-backed per-user serialization and to specify that replay uses sequential replay state rather than historical snapshots.

### Testing

- Ran `python -m pytest -q` which completed with all unit tests passing; database-backed tests were executed where available and the overall run reported `42 passed, 20 skipped` in the test environment used here.
- Ran formatting/lint checks with `black` and `ruff` and fixed files as needed so `black --check` and `ruff check` pass for the modified files.
- Ran `python -m compileall -q` and `git diff --check` to validate code compiles and no diff-check issues remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b8ae63784832890a29d24583b73ea)