### PR TITLE
Harden executor subprocess isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,42 @@ Set `COMMAND_TIMEOUT` (seconds) to limit how long each command may run.
 Commands are parsed with `shlex.split` before execution, so quoting rules follow
 POSIX shells but features like glob expansion are not performed.
 
+### Executor trust model and sandbox configuration
+
+Database users who can submit commands are **untrusted**. The executor worker,
+its PostgreSQL credentials, and the host outside `SHELL_ROOT` are trusted and
+must not be accessible to submitted commands. `run_subprocess` therefore builds
+a new environment containing only a fixed `PATH`, locale, the command account's
+identity variables, and values saved in `env_snapshot`. It never copies the
+worker environment, and rejects `DATABASE_URL` and `PG_CONN` even if a snapshot
+contains them.
+
+Production deployments must create a dedicated, unprivileged OS account and
+configure an absolute-path executable allowlist. The allowlist is the required
+process isolation boundary in the default deployment; commands not on it are
+rejected before execution. Run the worker as root only when it must switch to
+the command account (supplementary groups are cleared before `setuid`), or run
+the worker itself as that account:
+
+```bash
+useradd --system --create-home --home-dir /home/pg-shell-command pg-shell-command
+export EXECUTOR_USER=pg-shell-command
+export EXECUTOR_ALLOWED_COMMANDS=/usr/bin/printf:/usr/bin/python3
+export SHELL_ROOT=/home/pg-shell-command
+DATABASE_URL=postgresql://localhost/postgres python workers/executor_agent.py
+```
+
+Keep the allowlist minimal and ensure every allowed program and its libraries
+are not writable by the command account. Programs that can launch other
+processes, load arbitrary code, or read arbitrary paths (including Python) are
+not a security boundary and must not be allowed for untrusted tenants. A
+deployment needing those tools must add a stronger boundary (for example a
+rootless container or namespace sandbox with a read-only root filesystem,
+network disabled, capability dropping, resource limits, and only `SHELL_ROOT`
+mounted writable). `EXECUTOR_PATH`, `EXECUTOR_LANG`, and `EXECUTOR_LC_ALL` may
+override command defaults; these worker settings are used to construct the
+command environment rather than inherited wholesale.
+
 You can run `cleanup_agent.py` periodically. Command retention applies only to
 terminal statuses: `done` and `failed` commands older than `CLEANUP_DAYS` are
 deleted, while recent terminal commands and all `pending` or `running` commands

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -1,9 +1,35 @@
 import os
+import pwd
+import shutil
 import time
 
 import pytest
 import workers.executor_agent
 from workers.executor_agent import run_subprocess, handle_command
+
+
+@pytest.fixture(autouse=True)
+def configured_executor(monkeypatch, tmp_path):
+    """Use the test runner account while exercising the production controls."""
+    account = pwd.getpwuid(os.geteuid())
+    if account.pw_uid == 0:
+        account = pwd.getpwnam("nobody")
+        tmp_path.chmod(0o777)
+        parent = tmp_path.parent
+        while parent != parent.parent and parent != parent.parent.parent:
+            parent.chmod(0o755)
+            if parent == tmp_path.parents[2]:
+                break
+            parent = parent.parent
+    monkeypatch.setenv("EXECUTOR_USER", account.pw_name)
+    command_path = workers.executor_agent.DEFAULT_COMMAND_PATH
+    commands = [
+        shutil.which("python3", path=command_path),
+        shutil.which("sleep", path=command_path),
+    ]
+    monkeypatch.setenv(
+        "EXECUTOR_ALLOWED_COMMANDS", os.pathsep.join(filter(None, commands))
+    )
 
 
 def test_run_subprocess_combines_output(tmp_path):
@@ -80,6 +106,29 @@ def test_run_subprocess_passes_env_snapshot(monkeypatch, tmp_path):
     exit_code, output = run_subprocess(cmd, str(tmp_path), {"PGS_TEST_VAR": "hello"})
     assert exit_code == 0
     assert "hello" in output
+
+
+def test_run_subprocess_does_not_expose_worker_secrets(monkeypatch, tmp_path):
+    monkeypatch.setenv("WORKER_API_SECRET", "worker-only")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://secret")
+    script = (
+        'import os;print(os.getenv("WORKER_API_SECRET"));'
+        'print(os.getenv("DATABASE_URL"))'
+    )
+    cmd = f"python3 -c '{script}'"
+
+    exit_code, output = run_subprocess(cmd, str(tmp_path), None)
+
+    assert exit_code == 0
+    assert output.splitlines() == ["None", "None"]
+
+
+@pytest.mark.parametrize("reserved", ["DATABASE_URL", "PG_CONN"])
+def test_run_subprocess_rejects_reserved_snapshot_variables(
+    monkeypatch, tmp_path, reserved
+):
+    with pytest.raises(ValueError, match="reserved environment variable"):
+        run_subprocess("python3 -c 'pass'", str(tmp_path), {reserved: "secret"})
 
 
 def test_handle_command_uses_combined_output(monkeypatch):
@@ -342,7 +391,7 @@ def test_handle_command_missing_binary_marks_failed(monkeypatch, tmp_path):
 
     assert captured['status'] == 'failed'
     assert captured['exit_code'] == 1
-    assert 'No such file or directory' in captured['output']
+    assert 'not in EXECUTOR_ALLOWED_COMMANDS' in captured['output']
 
 
 def test_main_closes_connection_on_keyboard_interrupt(monkeypatch):

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -12,8 +12,10 @@ script.
 import json
 import logging
 import os
+import pwd
 import select
 import shlex
+import shutil
 import signal
 import subprocess
 import time
@@ -34,6 +36,8 @@ MAX_OUTPUT_BYTES = int(os.getenv("MAX_OUTPUT_BYTES", "65536"))
 TRUNCATION_SUFFIX = "...[truncated]"
 TERMINATION_GRACE_SECONDS = 0.5
 PIPE_DRAIN_TIMEOUT_SECONDS = 0.5
+RESERVED_COMMAND_ENV = frozenset({"DATABASE_URL", "PG_CONN"})
+DEFAULT_COMMAND_PATH = "/usr/local/bin:/usr/bin:/bin"
 
 
 def _update_channel_config(conn, channel: str) -> None:
@@ -139,14 +143,67 @@ def update_cwd(conn, user_id, cwd: str) -> None:
 
 
 def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]:
-    env: Dict[str, str] = os.environ.copy()
+    # Never inherit the worker's environment: it contains the database DSN and
+    # may contain unrelated orchestration credentials.
+    env: Dict[str, str] = {
+        "PATH": os.getenv("EXECUTOR_PATH", DEFAULT_COMMAND_PATH),
+        "LANG": os.getenv("EXECUTOR_LANG", "C.UTF-8"),
+        "LC_ALL": os.getenv("EXECUTOR_LC_ALL", "C.UTF-8"),
+    }
     if env_snapshot:
         if isinstance(env_snapshot, str):
-            env.update(json.loads(env_snapshot))
+            snapshot = json.loads(env_snapshot)
         else:
-            env.update(env_snapshot)
+            snapshot = env_snapshot
+        if not isinstance(snapshot, dict):
+            raise ValueError("env_snapshot must be a JSON object")
+        reserved = RESERVED_COMMAND_ENV.intersection(snapshot)
+        if reserved:
+            names = ", ".join(sorted(reserved))
+            raise ValueError(f"reserved environment variable(s): {names}")
+        if not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in snapshot.items()
+        ):
+            raise ValueError("env_snapshot keys and values must be strings")
+        env.update(snapshot)
 
     cmd_list = shlex.split(command)
+    if not cmd_list:
+        raise ValueError("command must not be empty")
+
+    allowed_setting = os.getenv("EXECUTOR_ALLOWED_COMMANDS", "")
+    allowed = {
+        os.path.realpath(path)
+        for path in allowed_setting.split(os.pathsep)
+        if path
+    }
+    executable = shutil.which(cmd_list[0], path=env["PATH"])
+    resolved_executable = os.path.realpath(executable) if executable else None
+    if resolved_executable not in allowed:
+        raise PermissionError(
+            f"command is not in EXECUTOR_ALLOWED_COMMANDS: {cmd_list[0]}"
+        )
+    cmd_list[0] = resolved_executable
+
+    executor_user = os.getenv("EXECUTOR_USER")
+    if not executor_user:
+        raise RuntimeError("EXECUTOR_USER must name a dedicated unprivileged account")
+    account = pwd.getpwnam(executor_user)
+    if account.pw_uid == 0:
+        raise RuntimeError("EXECUTOR_USER must be unprivileged")
+    if os.geteuid() != 0 and os.geteuid() != account.pw_uid:
+        raise PermissionError("worker cannot switch to EXECUTOR_USER")
+
+    def demote() -> None:
+        if os.geteuid() == 0:
+            os.setgroups([])
+            os.setgid(account.pw_gid)
+            os.setuid(account.pw_uid)
+
+    env.update(
+        {"HOME": account.pw_dir, "USER": account.pw_name, "LOGNAME": account.pw_name}
+    )
     proc = subprocess.Popen(
         cmd_list,
         cwd=cwd,
@@ -154,6 +211,7 @@ def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         start_new_session=os.name == "posix",
+        preexec_fn=demote if os.name == "posix" else None,
     )
 
     deadline = time.monotonic() + COMMAND_TIMEOUT


### PR DESCRIPTION
### Motivation

- Prevent worker process environment leaks and accidental exposure of DB credentials or orchestration secrets to executed commands by removing `os.environ` inheritance in `run_subprocess`.  
- Enforce a clear, auditable execution boundary by requiring an allowlist of absolute executables and a dedicated unprivileged account for running commands.  
- Make the intended trust model and required sandboxing explicit in the documentation so deployments can choose an appropriate isolation boundary.  

### Description

- Replace environment copying in `run_subprocess` with construction of a minimal environment containing `PATH`, locale defaults, and only values supplied in `env_snapshot`, and validate `env_snapshot` types via `json`.  
- Reject reserved database connection variables from snapshots by disallowing `DATABASE_URL` and `PG_CONN` in snapshots (`RESERVED_COMMAND_ENV`).  
- Add an absolute-path executable allowlist via `EXECUTOR_ALLOWED_COMMANDS` and resolve commands with `shutil.which` against the constructed `PATH`, rejecting commands not on the allowlist.  
- Require `EXECUTOR_USER` (a dedicated unprivileged account) and, when running as root, drop privileges with a `preexec_fn` that clears supplementary groups and calls `setgid`/`setuid`; also set `HOME`, `USER`, and `LOGNAME` in the command environment.  
- Add tests in `tests/test_executor_agent.py` (fixture `configured_executor`) that verify permitted snapshot variables are passed, worker-only secrets and DB credentials are not exposed, and reserved snapshot variables are rejected.  
- Document the executor trust model and recommended sandbox configuration in `README.md`, and add worker-side defaults (`DEFAULT_COMMAND_PATH`, `EXECUTOR_*` overrides).  

### Testing

- Ran Python compile checks with `python -m py_compile workers/executor_agent.py tests/test_executor_agent.py`, which succeeded.  
- Executed the full test module with `pytest -q` and observed passing results: `45 passed, 19 skipped`.  
- Ran repository sanity checks with `git diff --check` (no problems found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b8ae16ebc8328a2141c48c30150ed)