### PR TITLE
Add bounded leases and retry limits to executor claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ DATABASE_URL=postgresql://localhost/postgres python workers/executor_agent.py
 The executor agent will exit with an error if neither `DATABASE_URL` nor
 `PG_CONN` is set.
 Set `COMMAND_TIMEOUT` (seconds) to limit how long each command may run.
+Each executor claim also has a bounded lease. Configure its duration with
+`CLAIM_LEASE_SECONDS` (the default is `COMMAND_TIMEOUT + 10`) and identify an
+executor with `EXECUTOR_WORKER_ID` (the default is its hostname and process
+ID). After a worker disappears, another executor may retry the command when
+the lease expires. `MAX_COMMAND_ATTEMPTS` defaults to 3; when the final claim
+expires, the command is marked `failed` with an expiration diagnostic rather
+than retried indefinitely. Set the lease longer than the maximum expected
+execution time to avoid concurrent execution of a still-running command.
 Commands are parsed with `shlex.split` before execution, so quoting rules follow
 POSIX shells but features like glob expansion are not performed.
 

--- a/sql/init_schema.sql
+++ b/sql/init_schema.sql
@@ -27,7 +27,12 @@ CREATE TABLE IF NOT EXISTS commands (
   exit_code INT,
   cwd_snapshot TEXT,
   env_snapshot JSONB,
+  claimed_at TIMESTAMPTZ,
+  lease_expires_at TIMESTAMPTZ,
+  claimed_by TEXT,
+  attempt_count INT NOT NULL DEFAULT 0,
   completed_at TIMESTAMP,
+  CONSTRAINT commands_attempt_count_nonnegative CHECK (attempt_count >= 0),
   CONSTRAINT status_enum CHECK (status IN ('pending','running','done','failed'))
 );
 
@@ -50,6 +55,10 @@ ON CONFLICT (key) DO NOTHING;
 
 CREATE INDEX IF NOT EXISTS commands_status_submitted_at_idx
   ON commands (status, submitted_at);
+
+CREATE INDEX IF NOT EXISTS commands_running_lease_expires_at_idx
+  ON commands (lease_expires_at)
+  WHERE status = 'running';
 
 CREATE INDEX IF NOT EXISTS commands_user_id_id_idx
   ON commands (user_id, id);

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -1,5 +1,6 @@
 -- install.sql: convenience script to install pg_shell schema and functions
 \i sql/init_schema.sql
+\i sql/migrate_execution_claims.sql
 \i sql/migrate_replay_provenance_retention.sql
 \i sql/submit_command.sql
 \i sql/latest_output.sql -- updated latest_output with optional since_id filter

--- a/sql/migrate_execution_claims.sql
+++ b/sql/migrate_execution_claims.sql
@@ -1,0 +1,27 @@
+-- Add bounded execution-claim metadata to existing pg_shell installations.
+-- Every statement is safe to run repeatedly.
+ALTER TABLE commands ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ;
+ALTER TABLE commands ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ;
+ALTER TABLE commands ADD COLUMN IF NOT EXISTS claimed_by TEXT;
+ALTER TABLE commands ADD COLUMN IF NOT EXISTS attempt_count INT;
+
+UPDATE commands SET attempt_count = 0 WHERE attempt_count IS NULL;
+ALTER TABLE commands ALTER COLUMN attempt_count SET DEFAULT 0;
+ALTER TABLE commands ALTER COLUMN attempt_count SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'commands_attempt_count_nonnegative'
+      AND conrelid = 'commands'::regclass
+  ) THEN
+    ALTER TABLE commands
+      ADD CONSTRAINT commands_attempt_count_nonnegative
+      CHECK (attempt_count >= 0);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS commands_running_lease_expires_at_idx
+  ON commands (lease_expires_at)
+  WHERE status = 'running';

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import pytest
 # dependency order.
 SQL_FILES = (
     "sql/init_schema.sql",
+    "sql/migrate_execution_claims.sql",
     "sql/submit_command.sql",
     "sql/latest_output.sql",
     "sql/fork_session.sql",

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -3,7 +3,78 @@ import time
 
 import pytest
 import workers.executor_agent
-from workers.executor_agent import run_subprocess, handle_command
+from workers.executor_agent import fetch_pending, run_subprocess, handle_command, update_command
+
+
+class _ClaimCursor:
+    def __init__(self, row=None):
+        self.row = row
+        self.executions = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def execute(self, query, params=None):
+        self.executions.append((query, params))
+
+    def fetchone(self):
+        return self.row
+
+
+class _ClaimConnection:
+    autocommit = False
+
+    def __init__(self, row=None):
+        self.cursor_instance = _ClaimCursor(row)
+        self.commits = 0
+
+    def cursor(self, **kwargs):
+        return self.cursor_instance
+
+    def commit(self):
+        self.commits += 1
+
+
+def test_fetch_pending_claim_is_concurrency_safe_and_includes_stale_leases(monkeypatch):
+    row = {"id": 7, "user_id": "u", "attempt_count": 2}
+    conn = _ClaimConnection(row)
+    monkeypatch.setattr(workers.executor_agent, "CLAIM_LEASE_SECONDS", 15)
+    monkeypatch.setattr(workers.executor_agent, "MAX_COMMAND_ATTEMPTS", 3)
+    monkeypatch.setattr(workers.executor_agent, "WORKER_ID", "worker-test")
+
+    assert fetch_pending(conn) == row
+
+    claim_sql, params = conn.cursor_instance.executions[1]
+    assert "FOR UPDATE SKIP LOCKED" in claim_sql
+    assert "lease_expires_at IS NULL OR lease_expires_at <= now()" in claim_sql
+    assert "attempt_count = command.attempt_count + 1" in claim_sql
+    assert params == (3, 15, "worker-test")
+    assert conn.commits == 1
+
+
+def test_fetch_pending_exhausted_retry_has_diagnostic(monkeypatch):
+    conn = _ClaimConnection()
+    monkeypatch.setattr(workers.executor_agent, "MAX_COMMAND_ATTEMPTS", 4)
+
+    assert fetch_pending(conn) is None
+
+    reclaim_sql, params = conn.cursor_instance.executions[0]
+    assert "status = 'failed'" in reclaim_sql
+    assert "lease_expires_at = NULL" in reclaim_sql
+    assert "4 attempts" in params[0]
+
+
+def test_update_command_clears_claim_metadata():
+    conn = _ClaimConnection()
+    update_command(conn, 9, "done", "ok", 0)
+    query, params = conn.cursor_instance.executions[0]
+    assert "claimed_at=NULL" in query
+    assert "lease_expires_at=NULL" in query
+    assert "claimed_by=NULL" in query
+    assert params == ("done", "ok", 0, 9)
 
 
 def test_run_subprocess_combines_output(tmp_path):

--- a/tests/test_executor_integration.py
+++ b/tests/test_executor_integration.py
@@ -7,8 +7,31 @@ the unit tests in ``test_executor_agent.py`` stub out. They require
 """
 
 import uuid
+from pathlib import Path
+
+import psycopg2
 
 from workers.executor_agent import fetch_pending, handle_command
+
+
+def test_execution_claim_migration_is_idempotent(db_conn):
+    migration = Path("sql/migrate_execution_claims.sql").read_text()
+    with db_conn.cursor() as cur:
+        cur.execute(migration)
+        cur.execute(migration)
+        cur.execute(
+            """SELECT column_name
+               FROM information_schema.columns
+               WHERE table_name = 'commands'
+                 AND column_name IN
+                     ('claimed_at', 'lease_expires_at', 'claimed_by', 'attempt_count')"""
+        )
+        assert {row[0] for row in cur.fetchall()} == {
+            "claimed_at",
+            "lease_expires_at",
+            "claimed_by",
+            "attempt_count",
+        }
 
 
 def _create_user_with_env(conn, cwd: str) -> str:
@@ -86,3 +109,69 @@ def test_fetch_pending_returns_none_when_idle(db_conn):
         assert fetch_pending(db_conn) is None
     finally:
         db_conn.autocommit = True
+
+
+def test_concurrent_executors_claim_different_commands(db_conn, tmp_path):
+    user_id = _create_user_with_env(db_conn, str(tmp_path))
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT submit_command(%s, 'echo first')", (user_id,))
+        first_id = cur.fetchone()[0]
+        cur.execute("SELECT submit_command(%s, 'echo second')", (user_id,))
+        second_id = cur.fetchone()[0]
+
+    other = psycopg2.connect(db_conn.dsn)
+    db_conn.autocommit = False
+    other.autocommit = False
+    try:
+        first = fetch_pending(db_conn)
+        second = fetch_pending(other)
+        assert {first["id"], second["id"]} == {first_id, second_id}
+    finally:
+        db_conn.rollback()
+        db_conn.autocommit = True
+        other.close()
+
+
+def test_expired_claim_is_retried_then_fails_at_attempt_limit(
+    db_conn, monkeypatch, tmp_path
+):
+    monkeypatch.setattr("workers.executor_agent.MAX_COMMAND_ATTEMPTS", 2)
+    user_id = _create_user_with_env(db_conn, str(tmp_path))
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT submit_command(%s, 'echo stale')", (user_id,))
+        cmd_id = cur.fetchone()[0]
+        cur.execute(
+            """UPDATE commands
+               SET status='running', attempt_count=1,
+                   claimed_at=now() - interval '2 minutes',
+                   lease_expires_at=now() - interval '1 minute',
+                   claimed_by='dead-worker'
+               WHERE id=%s""",
+            (cmd_id,),
+        )
+
+    db_conn.autocommit = False
+    try:
+        reclaimed = fetch_pending(db_conn)
+        assert reclaimed["id"] == cmd_id
+        assert reclaimed["attempt_count"] == 2
+        with db_conn.cursor() as cur:
+            cur.execute(
+                "UPDATE commands SET lease_expires_at=now() - interval '1 second' WHERE id=%s",
+                (cmd_id,),
+            )
+        assert fetch_pending(db_conn) is None
+    finally:
+        db_conn.autocommit = True
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, output, claimed_at, lease_expires_at, claimed_by FROM commands WHERE id=%s",
+            (cmd_id,),
+        )
+        status, output, claimed_at, lease_expires_at, claimed_by = cur.fetchone()
+    assert status == "failed"
+    assert "2 attempts" in output
+    assert claimed_at is None
+    assert lease_expires_at is None
+    assert claimed_by is None

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -15,6 +15,7 @@ import os
 import select
 import shlex
 import signal
+import socket
 import subprocess
 import time
 from typing import Any, Dict
@@ -29,6 +30,9 @@ DEFAULT_LISTEN_CHANNEL = "new_command"
 LISTEN_CHANNEL_ENV = os.getenv("LISTEN_CHANNEL")
 LISTEN_CHANNEL = LISTEN_CHANNEL_ENV or DEFAULT_LISTEN_CHANNEL
 COMMAND_TIMEOUT = int(os.getenv("COMMAND_TIMEOUT", "30"))
+CLAIM_LEASE_SECONDS = int(os.getenv("CLAIM_LEASE_SECONDS", str(COMMAND_TIMEOUT + 10)))
+MAX_COMMAND_ATTEMPTS = int(os.getenv("MAX_COMMAND_ATTEMPTS", "3"))
+WORKER_ID = os.getenv("EXECUTOR_WORKER_ID") or f"{socket.gethostname()}:{os.getpid()}"
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 MAX_OUTPUT_BYTES = int(os.getenv("MAX_OUTPUT_BYTES", "65536"))
 TRUNCATION_SUFFIX = "...[truncated]"
@@ -100,21 +104,69 @@ def wait_for_notify(conn, timeout: float) -> None:
 
 
 def fetch_pending(conn) -> Dict[str, Any] | None:
+    """Atomically claim pending or lease-expired work for this worker.
+
+    An expired claim consumes an attempt. Once the configured limit has been
+    reached, it is terminally failed instead of being executed indefinitely.
+    """
+    if CLAIM_LEASE_SECONDS <= 0:
+        raise ValueError("CLAIM_LEASE_SECONDS must be greater than zero")
+    if MAX_COMMAND_ATTEMPTS <= 0:
+        raise ValueError("MAX_COMMAND_ATTEMPTS must be greater than zero")
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
-        cur.execute("BEGIN;")
+        if conn.autocommit:
+            raise ValueError("fetch_pending requires autocommit to be disabled")
         cur.execute(
             """
-            SELECT id, user_id, command, cwd_snapshot, env_snapshot
-            FROM commands
-            WHERE status = 'pending'
-            ORDER BY submitted_at
-            FOR UPDATE SKIP LOCKED
-            LIMIT 1
+            UPDATE commands
+            SET status = 'failed',
+                output = %s,
+                exit_code = 1,
+                completed_at = now(),
+                claimed_at = NULL,
+                lease_expires_at = NULL,
+                claimed_by = NULL
+            WHERE status = 'running'
+              AND (lease_expires_at IS NULL OR lease_expires_at <= now())
+              AND attempt_count >= %s
+            """,
+            (
+                f"Execution claim expired after {MAX_COMMAND_ATTEMPTS} attempts; "
+                "command was not retried again",
+                MAX_COMMAND_ATTEMPTS,
+            ),
+        )
+        cur.execute(
             """
+            WITH candidate AS (
+              SELECT id
+              FROM commands
+              WHERE (status = 'pending'
+                     OR (status = 'running' AND
+                         (lease_expires_at IS NULL OR lease_expires_at <= now())))
+                AND attempt_count < %s
+              ORDER BY submitted_at
+              FOR UPDATE SKIP LOCKED
+              LIMIT 1
+            )
+            UPDATE commands AS command
+            SET status = 'running',
+                claimed_at = now(),
+                lease_expires_at = now() + (%s * interval '1 second'),
+                claimed_by = %s,
+                attempt_count = command.attempt_count + 1,
+                completed_at = NULL
+            FROM candidate
+            WHERE command.id = candidate.id
+            RETURNING command.id, command.user_id, command.command,
+                      command.cwd_snapshot, command.env_snapshot,
+                      command.claimed_at, command.lease_expires_at,
+                      command.claimed_by, command.attempt_count
+            """,
+            (MAX_COMMAND_ATTEMPTS, CLAIM_LEASE_SECONDS, WORKER_ID),
         )
         row = cur.fetchone()
         if row:
-            cur.execute("UPDATE commands SET status='running' WHERE id=%s", (row["id"],))
             logging.info("Fetched command %s for user %s", row["id"], row["user_id"])
         conn.commit()
         return row
@@ -123,7 +175,10 @@ def fetch_pending(conn) -> Dict[str, Any] | None:
 def update_command(conn, cmd_id: int, status: str, output: str, exit_code: int) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "UPDATE commands SET status=%s, output=%s, exit_code=%s, completed_at=now() WHERE id=%s",
+            """UPDATE commands
+               SET status=%s, output=%s, exit_code=%s, completed_at=now(),
+                   claimed_at=NULL, lease_expires_at=NULL, claimed_by=NULL
+               WHERE id=%s""",
             (status, output, exit_code, cmd_id),
         )
     conn.commit()


### PR DESCRIPTION
### Motivation
- Prevent commands from being executed indefinitely by other workers after a crash by adding explicit execution-claim metadata and bounded leases. 
- Make retry behavior observable and configurable so commands that repeatedly time out or are never completed are eventually marked terminal with a helpful diagnostic. 
- Ensure existing installations can be upgraded safely with an idempotent migration that backfills attempt counters and installs constraints and indexes.

### Description
- Extend the `commands` table with `claimed_at`, `lease_expires_at`, `claimed_by`, and `attempt_count`, plus a nonnegative constraint and an index for stale-running lookups, and add an idempotent migration at `sql/migrate_execution_claims.sql`.
- Update `fetch_pending` to atomically reclaim expired claims and/or claim pending work using a `WITH ... FOR UPDATE SKIP LOCKED` pattern, set a bounded lease (`CLAIM_LEASE_SECONDS`), record `claimed_by` (worker id), and increment `attempt_count`, and to terminally fail rows that have exhausted `MAX_COMMAND_ATTEMPTS` with a diagnostic.
- Clear claim metadata (`claimed_at`, `lease_expires_at`, `claimed_by`) when `update_command` records a terminal result, and validate `CLAIM_LEASE_SECONDS`/`MAX_COMMAND_ATTEMPTS` and proper transaction/autocommit usage in `fetch_pending`.
- Add configuration defaults and a worker identifier: `CLAIM_LEASE_SECONDS` (default `COMMAND_TIMEOUT + 10`), `MAX_COMMAND_ATTEMPTS` (default `3`), and `EXECUTOR_WORKER_ID` (defaults to `hostname:pid`), and document them in the `README`.
- Add unit tests to assert concurrency-safe SQL, stale-lease inclusion, retry diagnostics, and claim cleanup, and add integration tests for migration idempotency, parallel claiming, stale-lease recovery, retry exhaustion, and metadata cleanup; update test setup to run the migration during schema install.

### Testing
- Ran `pytest -q`, all tests passed: `45 passed, 22 skipped` (skipped because `TEST_DATABASE_URL` was not configured). 
- Verified `workers/executor_agent.py` compiles with `python -m py_compile workers/executor_agent.py` (success). 
- Verified repository checks with `git diff --check` (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b8ae32ab88328a83a14b0469cc550)