### PR TITLE
Skip browser UI tests when Playwright is unavailable

### DIFF
--- a/tests/test_html_ui.py
+++ b/tests/test_html_ui.py
@@ -7,7 +7,13 @@ import threading
 from pathlib import Path
 
 import pytest
-from playwright.sync_api import expect, sync_playwright
+
+playwright_sync_api = pytest.importorskip(
+    "playwright.sync_api",
+    reason="Playwright is required for browser-level UI tests",
+)
+expect = playwright_sync_api.expect
+sync_playwright = playwright_sync_api.sync_playwright
 
 
 HTML_DIR = Path(__file__).parents[1] / "html"


### PR DESCRIPTION
### Motivation
- Prevent test collection from failing with `ModuleNotFoundError` when the optional `playwright` Python package is not installed by making browser UI tests opt-in.

### Description
- Replace the direct `from playwright.sync_api import expect, sync_playwright` import in `tests/test_html_ui.py` with `pytest.importorskip("playwright.sync_api")` and rebind `expect` and `sync_playwright` so tests are skipped cleanly when Playwright is absent.

### Testing
- Ran `pytest -q` which completed with `46 passed, 21 skipped`.
- Ran `python -m compileall -q cli workers tests` and `git diff --check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b8da25dd48328944f68f9c0528742)