### PR TITLE
Add executor command leases and abandoned-work recovery

### DIFF
--- a/sql/init_schema.sql
+++ b/sql/init_schema.sql
@@ -27,6 +27,9 @@ CREATE TABLE IF NOT EXISTS commands (
   exit_code INT,
   cwd_snapshot TEXT,
   env_snapshot JSONB,
+  claimed_at TIMESTAMP,
+  lease_expires_at TIMESTAMP,
+  worker_id TEXT,
   completed_at TIMESTAMP,
   CONSTRAINT status_enum CHECK (status IN ('pending','running','done','failed'))
 );
@@ -50,6 +53,10 @@ ON CONFLICT (key) DO NOTHING;
 
 CREATE INDEX IF NOT EXISTS commands_status_submitted_at_idx
   ON commands (status, submitted_at);
+
+CREATE INDEX IF NOT EXISTS commands_running_lease_idx
+  ON commands (lease_expires_at)
+  WHERE status = 'running';
 
 CREATE INDEX IF NOT EXISTS commands_user_id_id_idx
   ON commands (user_id, id);

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -1,5 +1,6 @@
 -- install.sql: convenience script to install pg_shell schema and functions
 \i sql/init_schema.sql
+\i sql/migrate_command_leases.sql
 \i sql/migrate_replay_provenance_retention.sql
 \i sql/submit_command.sql
 \i sql/latest_output.sql -- updated latest_output with optional since_id filter

--- a/sql/migrate_command_leases.sql
+++ b/sql/migrate_command_leases.sql
@@ -1,0 +1,9 @@
+-- Add executor lease metadata to installations created before command leases.
+-- Every statement is safe to run repeatedly.
+ALTER TABLE commands ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMP;
+ALTER TABLE commands ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMP;
+ALTER TABLE commands ADD COLUMN IF NOT EXISTS worker_id TEXT;
+
+CREATE INDEX IF NOT EXISTS commands_running_lease_idx
+  ON commands (lease_expires_at)
+  WHERE status = 'running';

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -1,9 +1,32 @@
 import os
 import time
+from pathlib import Path
 
 import pytest
 import workers.executor_agent
 from workers.executor_agent import run_subprocess, handle_command
+
+
+def test_schema_and_migration_define_idempotent_command_leases():
+    schema = Path("sql/init_schema.sql").read_text()
+    migration = Path("sql/migrate_command_leases.sql").read_text()
+
+    for column in ("claimed_at", "lease_expires_at", "worker_id"):
+        assert column in schema
+        assert f"ADD COLUMN IF NOT EXISTS {column}" in migration
+
+
+def test_run_subprocess_refreshes_lease(monkeypatch, tmp_path):
+    monkeypatch.setattr(workers.executor_agent, "LEASE_REFRESH_SECONDS", 0.01)
+    refreshes = []
+    exit_code, _ = run_subprocess(
+        "python3 -c 'import time; time.sleep(.15)'",
+        str(tmp_path),
+        None,
+        lambda: refreshes.append(True),
+    )
+    assert exit_code == 0
+    assert refreshes
 
 
 def test_run_subprocess_combines_output(tmp_path):
@@ -85,7 +108,7 @@ def test_run_subprocess_passes_env_snapshot(monkeypatch, tmp_path):
 def test_handle_command_uses_combined_output(monkeypatch):
     captured = {}
 
-    def fake_run_subprocess(command, cwd, env):
+    def fake_run_subprocess(command, cwd, env, lease_refresh=None):
         return 1, "stdout+stderr"
 
     def fake_update_command(conn, cmd_id, status, output, exit_code):
@@ -256,7 +279,7 @@ def test_handle_command_cd_absolute_outside_root_fails(tmp_path, monkeypatch):
 def test_handle_command_cd_with_extra_args_runs_subprocess(monkeypatch):
     captured: dict = {}
 
-    def fake_run_subprocess(command, cwd, env):
+    def fake_run_subprocess(command, cwd, env, lease_refresh=None):
         captured['command'] = command
         return 0, ''
 
@@ -361,6 +384,7 @@ def test_main_closes_connection_on_keyboard_interrupt(monkeypatch):
 
     monkeypatch.setattr('workers.executor_agent.get_conn', fake_get_conn)
     monkeypatch.setattr('workers.executor_agent.setup_listener', lambda conn: None)
+    monkeypatch.setattr('workers.executor_agent.recover_dead_workers', lambda conn: 0)
     monkeypatch.setattr('workers.executor_agent.fetch_pending', fake_fetch_pending)
     monkeypatch.setattr('workers.executor_agent.wait_for_notify', lambda conn, timeout: None)
 

--- a/tests/test_executor_integration.py
+++ b/tests/test_executor_integration.py
@@ -7,10 +7,16 @@ the unit tests in ``test_executor_agent.py`` stub out. They require
 """
 
 import uuid
+from pathlib import Path
 
 import psycopg2
 
-from workers.executor_agent import fetch_pending, handle_command
+from workers.executor_agent import (
+    WORKER_HOST,
+    fetch_pending,
+    handle_command,
+    recover_dead_workers,
+)
 
 
 def _create_user_with_env(conn, cwd: str) -> str:
@@ -45,15 +51,75 @@ def test_executor_runs_pending_command_end_to_end(db_conn):
 
     with db_conn.cursor() as cur:
         cur.execute(
-            "SELECT status, output, exit_code, completed_at FROM commands WHERE id = %s",
+            """SELECT status, output, exit_code, completed_at,
+                      claimed_at, lease_expires_at, worker_id
+                 FROM commands WHERE id = %s""",
             (cmd_id,),
         )
-        status, output, exit_code, completed_at = cur.fetchone()
+        (
+            status,
+            output,
+            exit_code,
+            completed_at,
+            claimed_at,
+            lease_expires_at,
+            worker_id,
+        ) = cur.fetchone()
 
     assert status == "done"
     assert "integration-ok" in output
     assert exit_code == 0
     assert completed_at is not None
+    assert claimed_at is None
+    assert lease_expires_at is None
+    assert worker_id is None
+
+
+def test_executor_reclaims_abandoned_command_and_unblocks_user(db_conn):
+    user_id = _create_user_with_env(db_conn, "/tmp")
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT submit_command(%s, %s)", (user_id, "echo recovered"))
+        abandoned_id = cur.fetchone()[0]
+        cur.execute("SELECT submit_command(%s, %s)", (user_id, "echo next"))
+        next_id = cur.fetchone()[0]
+        cur.execute(
+            """
+            UPDATE commands
+               SET status='running', claimed_at=now() - interval '2 minutes',
+                   lease_expires_at=now() + interval '1 hour',
+                   worker_id=%s
+             WHERE id=%s
+            """,
+            (f"{WORKER_HOST}:2147483647:old-worker", abandoned_id),
+        )
+
+    worker = psycopg2.connect(db_conn.dsn)
+    try:
+        # Startup recovery does not need to wait for the lease when its local
+        # owner PID can be identified conclusively as dead.
+        assert recover_dead_workers(worker) == 1
+        recovered = fetch_pending(worker)
+        assert recovered["id"] == abandoned_id
+        handle_command(worker, recovered)
+
+        following = fetch_pending(worker)
+        assert following["id"] == next_id
+        handle_command(worker, following)
+    finally:
+        worker.close()
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, status, output FROM commands WHERE id IN (%s, %s) ORDER BY id",
+            (abandoned_id, next_id),
+        )
+        rows = cur.fetchall()
+    assert [(row[0], row[1]) for row in rows] == [
+        (abandoned_id, "done"),
+        (next_id, "done"),
+    ]
+    assert "recovered" in rows[0][2]
+    assert "next" in rows[1][2]
 
 
 def test_executor_cd_updates_environment(db_conn, monkeypatch, tmp_path):
@@ -88,6 +154,38 @@ def test_fetch_pending_returns_none_when_idle(db_conn):
         assert fetch_pending(db_conn) is None
     finally:
         db_conn.autocommit = True
+
+
+def test_fetch_pending_reclaims_expired_lease(db_conn):
+    user_id = _create_user_with_env(db_conn, "/tmp")
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT submit_command(%s, %s)", (user_id, "echo expired"))
+        cmd_id = cur.fetchone()[0]
+        cur.execute(
+            """UPDATE commands SET status='running', claimed_at=now(),
+                      lease_expires_at=now() - interval '1 second', worker_id='gone'
+                 WHERE id=%s""",
+            (cmd_id,),
+        )
+
+    worker = psycopg2.connect(db_conn.dsn)
+    try:
+        row = fetch_pending(worker)
+        assert row["id"] == cmd_id
+        handle_command(worker, row)
+    finally:
+        worker.close()
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT status FROM commands WHERE id=%s", (cmd_id,))
+        assert cur.fetchone()[0] == "done"
+
+
+def test_command_lease_migration_is_idempotent(db_conn):
+    migration = Path("sql/migrate_command_leases.sql").read_text()
+    with db_conn.cursor() as cur:
+        cur.execute(migration)
+        cur.execute(migration)
 
 
 def test_queued_commands_use_sequential_per_user_environment(

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -15,8 +15,10 @@ import os
 import select
 import shlex
 import signal
+import socket
 import subprocess
 import time
+import uuid
 from typing import Any, Dict
 
 from psycopg2 import sql, errors
@@ -34,6 +36,16 @@ MAX_OUTPUT_BYTES = int(os.getenv("MAX_OUTPUT_BYTES", "65536"))
 TRUNCATION_SUFFIX = "...[truncated]"
 TERMINATION_GRACE_SECONDS = 0.5
 PIPE_DRAIN_TIMEOUT_SECONDS = 0.5
+LEASE_SECONDS = max(float(os.getenv("COMMAND_LEASE_SECONDS", "60")), 1.0)
+LEASE_REFRESH_SECONDS = max(
+    0.25,
+    min(
+        float(os.getenv("LEASE_REFRESH_SECONDS", str(LEASE_SECONDS / 3))),
+        LEASE_SECONDS / 2,
+    ),
+)
+WORKER_HOST = socket.gethostname()
+WORKER_ID = f"{WORKER_HOST}:{os.getpid()}:{uuid.uuid4()}"
 
 
 def _update_channel_config(conn, channel: str) -> None:
@@ -100,19 +112,28 @@ def wait_for_notify(conn, timeout: float) -> None:
 
 
 def fetch_pending(conn) -> Dict[str, Any] | None:
-    """Claim the next command while holding a session-level per-user lock.
+    """Atomically reclaim expired work and claim the next eligible command.
 
-    The advisory lock remains held after this function commits and is released
-    by :func:`handle_command`.  Consequently another executor connection cannot
-    run a command for the same user concurrently.  Snapshots are refreshed from
-    the user's effective environment at claim time, after all preceding
-    commands have reached a terminal state.
+    The earlier-command predicate preserves per-user serialization, while row
+    locks prevent concurrent executors from claiming the same command.
+    Snapshots are refreshed from the user's effective environment at claim
+    time, after all preceding commands have reached a terminal state.
     """
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute("BEGIN;")
+        # Requeue abandoned work in the same transaction as the next claim.
+        # Row locks and SKIP LOCKED make this safe with concurrent executors.
+        cur.execute(
+            """
+            UPDATE commands
+               SET status = 'pending', claimed_at = NULL,
+                   lease_expires_at = NULL, worker_id = NULL
+             WHERE status = 'running'
+               AND (lease_expires_at IS NULL OR lease_expires_at < now())
+            """
+        )
         cur.execute("""
-            SELECT c.id, c.user_id, c.command, e.cwd, e.env,
-                   hashtextextended(c.user_id::text, 0) AS claim_lock_key
+            SELECT c.id, c.user_id, c.command, e.cwd, e.env
             FROM commands AS c
             JOIN environments AS e ON e.user_id = c.user_id
             WHERE c.status = 'pending'
@@ -130,17 +151,16 @@ def fetch_pending(conn) -> Dict[str, Any] | None:
             """)
         row = cur.fetchone()
         if row:
-            cur.execute("SELECT pg_try_advisory_lock(%s)", (row["claim_lock_key"],))
-            if not cur.fetchone()[0]:
-                conn.commit()
-                return None
             cur.execute(
                 """
                 UPDATE commands
-                   SET status = 'running', cwd_snapshot = %s, env_snapshot = %s
+                   SET status = 'running', cwd_snapshot = %s, env_snapshot = %s,
+                       claimed_at = now(),
+                       lease_expires_at = now() + (%s * interval '1 second'),
+                       worker_id = %s
                  WHERE id = %s
                 """,
-                (row["cwd"], row["env"], row["id"]),
+                (row["cwd"], row["env"], LEASE_SECONDS, WORKER_ID, row["id"]),
             )
             row["cwd_snapshot"] = row.pop("cwd")
             row["env_snapshot"] = row.pop("env")
@@ -152,7 +172,10 @@ def fetch_pending(conn) -> Dict[str, Any] | None:
 def update_command(conn, cmd_id: int, status: str, output: str, exit_code: int) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "UPDATE commands SET status=%s, output=%s, exit_code=%s, completed_at=now() WHERE id=%s",
+            """UPDATE commands
+                  SET status=%s, output=%s, exit_code=%s, completed_at=now(),
+                      claimed_at=NULL, lease_expires_at=NULL, worker_id=NULL
+                WHERE id=%s""",
             (status, output, exit_code, cmd_id),
         )
     conn.commit()
@@ -167,7 +190,9 @@ def update_cwd(conn, user_id, cwd: str) -> None:
     conn.commit()
 
 
-def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]:
+def run_subprocess(
+    command: str, cwd: str, env_snapshot: Any, lease_refresh=None
+) -> tuple[int, str]:
     env: Dict[str, str] = os.environ.copy()
     if env_snapshot:
         if isinstance(env_snapshot, str):
@@ -192,9 +217,13 @@ def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]
     termination_deadline = None
     drain_deadline = None
     fds = [proc.stdout, proc.stderr]
+    next_lease_refresh = time.monotonic() + LEASE_REFRESH_SECONDS
 
     while fds:
         now = time.monotonic()
+        if lease_refresh is not None and now >= next_lease_refresh:
+            lease_refresh()
+            next_lease_refresh = now + LEASE_REFRESH_SECONDS
         if now >= deadline and not timed_out:
             if os.name == "posix":
                 try:
@@ -262,24 +291,57 @@ def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]
     return exit_code, text
 
 
-def _release_user_claim(conn, row: Dict[str, Any]) -> None:
-    lock_key = row.get("claim_lock_key")
-    if lock_key is None:
-        return
-    # A command-side database error may have left the transaction aborted;
-    # advisory unlock must still be allowed to run before this worker polls.
-    conn.rollback()
+def refresh_lease(conn, cmd_id: int) -> None:
+    """Extend a lease only while this process still owns the command."""
     with conn.cursor() as cur:
-        cur.execute("SELECT pg_advisory_unlock(%s)", (lock_key,))
+        cur.execute(
+            """
+            UPDATE commands
+               SET lease_expires_at = now() + (%s * interval '1 second')
+             WHERE id = %s AND status = 'running' AND worker_id = %s
+            """,
+            (LEASE_SECONDS, cmd_id, WORKER_ID),
+        )
     conn.commit()
 
 
+def recover_dead_workers(conn) -> int:
+    """Requeue leases owned by PIDs known to be dead on this host."""
+    prefix = f"{WORKER_HOST}:"
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT DISTINCT worker_id FROM commands WHERE status='running' AND worker_id LIKE %s",
+            (prefix + "%",),
+        )
+        dead = []
+        for (worker_id,) in cur.fetchall():
+            try:
+                pid = int(worker_id[len(prefix):].split(":", 1)[0])
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                dead.append(worker_id)
+            except (ValueError, PermissionError):
+                continue
+        if dead:
+            cur.execute(
+                """
+                UPDATE commands
+                   SET status='pending', claimed_at=NULL,
+                       lease_expires_at=NULL, worker_id=NULL
+                 WHERE status='running' AND worker_id = ANY(%s)
+                """,
+                (dead,),
+            )
+            recovered = cur.rowcount
+        else:
+            recovered = 0
+    conn.commit()
+    return recovered
+
+
 def handle_command(conn, row: Dict[str, Any]) -> None:
-    """Execute a claimed command and always release its per-user claim."""
-    try:
-        _handle_command(conn, row)
-    finally:
-        _release_user_claim(conn, row)
+    """Execute a claimed command."""
+    _handle_command(conn, row)
 
 
 def _handle_command(conn, row: Dict[str, Any]) -> None:
@@ -341,7 +403,10 @@ def _handle_command(conn, row: Dict[str, Any]) -> None:
 
     try:
         exit_code, output = run_subprocess(
-            command, row["cwd_snapshot"], row["env_snapshot"]
+            command,
+            row["cwd_snapshot"],
+            row["env_snapshot"],
+            lambda: refresh_lease(conn, row["id"]),
         )
     except Exception as exc:
         logging.exception(
@@ -373,6 +438,9 @@ def main() -> None:
     conn = get_conn()
     try:
         setup_listener(conn)
+        recovered = recover_dead_workers(conn)
+        if recovered:
+            logging.info("Recovered %s commands from dead workers", recovered)
         while True:
             row = fetch_pending(conn)
             if row:


### PR DESCRIPTION
### Motivation
- Prevent long-running commands from being double-claimed by other executors and allow executors to recover work abandoned by dead workers.
- Make schema changes safe for existing installations and provide an idempotent migration path for older deployments.

### Description
- Add `claimed_at`, `lease_expires_at`, and `worker_id` columns to `commands` and create a partial index `commands_running_lease_idx` for running leases in `sql/init_schema.sql` and an idempotent `sql/migrate_command_leases.sql`, and include the migration from `sql/install.sql`.
- Update `workers/executor_agent.py` to atomically requeue expired `running` rows before claiming work, record lease metadata when claiming, and clear lease metadata in `update_command` when a command reaches a terminal state.
- Add configurable lease and refresh intervals (`COMMAND_LEASE_SECONDS`, `LEASE_REFRESH_SECONDS`) and make `run_subprocess` accept a `lease_refresh` callback that is invoked periodically while a subprocess is active to extend the lease.
- Add `refresh_lease(conn, cmd_id)` to extend a lease and `recover_dead_workers(conn)` that identifies dead local worker PIDs (matching the host prefix in `worker_id`) and requeues their `running` commands at executor startup.
- Add unit tests for schema/migration presence and lease-refresh behavior and integration tests that exercise expired-lease reclaiming, dead-worker recovery, idempotent migration, and verification that completed commands have lease metadata cleared.

### Testing
- Ran `python -m pytest -q`, resulting in `48 passed, 24 skipped` (PostgreSQL-dependent tests skipped when `TEST_DATABASE_URL` was not provided). 
- Verified `workers/executor_agent.py` compiles with `python -m py_compile workers/executor_agent.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cc80409608328a87d5fb7778d3ac4)