### PR TITLE
Add explicit session identity and non-destructive session forks

### DIFF
--- a/cli/shell_cli.py
+++ b/cli/shell_cli.py
@@ -48,7 +48,8 @@ DEFAULT_TIMEOUT = float(os.getenv("PG_SHELL_TIMEOUT", "30"))
 
 
 def exec_command(
-    base_url: str, user_id: str, cmd: str, timeout: float = DEFAULT_TIMEOUT
+    base_url: str, user_id: str, session_id: str, cmd: str,
+    timeout: float = DEFAULT_TIMEOUT,
 ) -> int:
     """Submit a command for execution.
 
@@ -72,7 +73,11 @@ def exec_command(
     try:
         resp = requests.post(
             f"{base_url}/rpc/submit_command",
-            json={"p_user_id": user_id, "p_command": cmd},
+            json={
+                "p_user_id": user_id,
+                "p_session_id": session_id,
+                "p_command": cmd,
+            },
             timeout=timeout,
             headers=_POST_HEADERS,
         )
@@ -124,7 +129,8 @@ def fork_session(
 
 
 def replay_session(
-    base_url: str, user_id: str, start_id: int, timeout: float = DEFAULT_TIMEOUT
+    base_url: str, user_id: str, session_id: str, start_id: int,
+    timeout: float = DEFAULT_TIMEOUT,
 ) -> int:
     """Replay a user's command history from a starting command.
 
@@ -151,7 +157,11 @@ def replay_session(
     try:
         resp = requests.post(
             f"{base_url}/rpc/replay_session",
-            json={"p_user_id": user_id, "p_start_id": start_id},
+            json={
+                "p_user_id": user_id,
+                "p_session_id": session_id,
+                "p_start_id": start_id,
+            },
             timeout=timeout,
             headers=_POST_HEADERS,
         )
@@ -167,6 +177,7 @@ def replay_session(
 def tail_output(
     base_url: str,
     user_id: str,
+    session_id: str,
     interval: float = 1.0,
     since: int | None = None,
     timeout: float = DEFAULT_TIMEOUT,
@@ -186,7 +197,7 @@ def tail_output(
     polls_remaining = max_polls
     try:
         while True:
-            params = {"p_user_id": user_id}
+            params = {"p_user_id": user_id, "p_session_id": session_id}
 
             if last_id is not None:
                 params["p_since_id"] = last_id
@@ -259,10 +270,12 @@ def main(argv: list[str] | None = None) -> int:
 
     exec_p = sub.add_parser("exec", help="Submit a command")
     exec_p.add_argument("--user", required=True, help="User ID")
+    exec_p.add_argument("--session", required=True, help="Session ID")
     exec_p.add_argument("--cmd", required=True, help="Command text")
 
     replay_p = sub.add_parser("replay", help="Replay a session from a starting command")
     replay_p.add_argument("--user", required=True, help="User ID")
+    replay_p.add_argument("--session", required=True, help="Session ID")
     replay_p.add_argument(
         "--start", type=int, required=True, help="Command ID to start replaying from"
     )
@@ -273,6 +286,7 @@ def main(argv: list[str] | None = None) -> int:
 
     tail_p = sub.add_parser("tail", help="Tail latest output")
     tail_p.add_argument("--user", required=True, help="User ID")
+    tail_p.add_argument("--session", required=True, help="Session ID")
     tail_p.add_argument("--interval", type=float, default=1.0, help="Polling interval seconds")
     tail_p.add_argument("--since", type=int, help="Start tailing after this command ID")
     tail_p.add_argument("--max-polls", type=int, help="Maximum number of polls before exiting")
@@ -280,15 +294,18 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "exec":
-        rc = exec_command(args.base_url, args.user, args.cmd, args.timeout)
+        rc = exec_command(args.base_url, args.user, args.session, args.cmd, args.timeout)
     elif args.command == "replay":
-        rc = replay_session(args.base_url, args.user, args.start, args.timeout)
+        rc = replay_session(
+            args.base_url, args.user, args.session, args.start, args.timeout
+        )
     elif args.command == "fork":
         rc = fork_session(args.base_url, args.user, args.at, args.timeout)
     elif args.command == "tail":
         rc = tail_output(
             args.base_url,
             args.user,
+            args.session,
             args.interval,
             args.since,
             args.timeout,

--- a/html/index.html
+++ b/html/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <div id="output"
-  hx-get="/rpc/latest_output?p_user_id=USER_ID"
+  hx-get="/rpc/latest_output?p_user_id=USER_ID&amp;p_session_id=SESSION_ID"
   hx-trigger="load, every 1s"
   hx-swap="none">
 </div>
@@ -24,6 +24,7 @@
   hx-encoding="json"
 >
   <input type="hidden" name="p_user_id" value="USER_ID" />
+  <input type="hidden" name="p_session_id" value="SESSION_ID" />
   <input name="p_command" autocomplete="off" autofocus placeholder="Enter command…" />
 </form>
 </body>

--- a/sql/fork_session.sql
+++ b/sql/fork_session.sql
@@ -5,6 +5,7 @@ CREATE OR REPLACE FUNCTION fork_session(p_user_id UUID, p_source_command_id INTE
 RETURNS UUID LANGUAGE plpgsql AS $$
 DECLARE
   src RECORD;
+  new_session_id UUID := gen_random_uuid();
 BEGIN
   SELECT cwd_snapshot, env_snapshot
     INTO src
@@ -15,15 +16,11 @@ BEGIN
     RAISE EXCEPTION 'source command not found or forbidden';
   END IF;
 
-  INSERT INTO environments(user_id, cwd, env)
-    VALUES (p_user_id,
+  INSERT INTO environments(session_id, user_id, cwd, env)
+    VALUES (new_session_id, p_user_id,
             COALESCE(src.cwd_snapshot, '/home/sandbox'),
-            COALESCE(src.env_snapshot, '{}'::jsonb))
-    ON CONFLICT (user_id) DO UPDATE
-      SET cwd = EXCLUDED.cwd,
-          env = EXCLUDED.env,
-          updated_at = now();
+            COALESCE(src.env_snapshot, '{}'::jsonb));
 
-  RETURN p_user_id;
+  RETURN new_session_id;
 END;
 $$;

--- a/sql/init_schema.sql
+++ b/sql/init_schema.sql
@@ -7,15 +7,18 @@ CREATE TABLE IF NOT EXISTS users (
 );
 
 CREATE TABLE IF NOT EXISTS environments (
-  user_id UUID PRIMARY KEY REFERENCES users(id),
+  session_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id),
   cwd TEXT NOT NULL DEFAULT '/home/sandbox',
   env JSONB NOT NULL DEFAULT '{}',
-  updated_at TIMESTAMP NOT NULL DEFAULT now()
+  updated_at TIMESTAMP NOT NULL DEFAULT now(),
+  UNIQUE (session_id, user_id)
 );
 
 CREATE TABLE IF NOT EXISTS commands (
   id SERIAL PRIMARY KEY,
   user_id UUID NOT NULL REFERENCES users(id),
+  session_id UUID NOT NULL,
   command TEXT NOT NULL,
   -- Replay rows are retained independently of their source command. Once the
   -- source ages out, its nullable provenance link is cleared.
@@ -28,7 +31,10 @@ CREATE TABLE IF NOT EXISTS commands (
   cwd_snapshot TEXT,
   env_snapshot JSONB,
   completed_at TIMESTAMP,
-  CONSTRAINT status_enum CHECK (status IN ('pending','running','done','failed'))
+  CONSTRAINT status_enum CHECK (status IN ('pending','running','done','failed')),
+  CONSTRAINT commands_session_owner_fkey
+    FOREIGN KEY (session_id, user_id)
+    REFERENCES environments(session_id, user_id)
 );
 
 CREATE TABLE IF NOT EXISTS pg_shell_config (
@@ -51,12 +57,5 @@ ON CONFLICT (key) DO NOTHING;
 CREATE INDEX IF NOT EXISTS commands_status_submitted_at_idx
   ON commands (status, submitted_at);
 
-CREATE INDEX IF NOT EXISTS commands_user_id_id_idx
-  ON commands (user_id, id);
-
 CREATE INDEX IF NOT EXISTS commands_status_completed_at_idx
   ON commands (status, completed_at, id);
-  
-CREATE INDEX IF NOT EXISTS commands_user_replay_source_idx
-  ON commands (user_id, replay_of_command_id)
-  WHERE replay_of_command_id IS NOT NULL;

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -1,5 +1,6 @@
 -- install.sql: convenience script to install pg_shell schema and functions
 \i sql/init_schema.sql
+\i sql/migrate_session_identity.sql
 \i sql/migrate_replay_provenance_retention.sql
 \i sql/submit_command.sql
 \i sql/latest_output.sql -- updated latest_output with optional since_id filter
@@ -8,4 +9,4 @@
 
 -- Ensure supporting indexes exist on commands for executor and query performance
 CREATE INDEX IF NOT EXISTS commands_status_submitted_at_idx ON commands (status, submitted_at);
-CREATE INDEX IF NOT EXISTS commands_user_id_id_idx ON commands (user_id, id);
+CREATE INDEX IF NOT EXISTS commands_session_id_id_idx ON commands (session_id, id);

--- a/sql/latest_output.sql
+++ b/sql/latest_output.sql
@@ -3,8 +3,11 @@
 
 DROP FUNCTION IF EXISTS latest_output(UUID);
 DROP FUNCTION IF EXISTS latest_output(UUID, INTEGER);
+DROP FUNCTION IF EXISTS latest_output(UUID, UUID, INTEGER);
 
-CREATE OR REPLACE FUNCTION latest_output(p_user_id UUID, p_since_id INTEGER DEFAULT 0)
+CREATE OR REPLACE FUNCTION latest_output(
+  p_user_id UUID, p_session_id UUID, p_since_id INTEGER DEFAULT 0
+)
 RETURNS TABLE(
     id INTEGER,
     command TEXT,
@@ -23,7 +26,8 @@ BEGIN
         SELECT c.id, c.command, c.output, c.exit_code, c.status,
                c.submitted_at, c.completed_at
         FROM commands c
-        WHERE c.user_id = p_user_id AND c.id > p_since_id
+        WHERE c.user_id = p_user_id AND c.session_id = p_session_id
+          AND c.id > p_since_id
         ORDER BY c.id DESC
         LIMIT 20;
     ELSE
@@ -31,7 +35,8 @@ BEGIN
         SELECT c.id, c.command, c.output, c.exit_code, c.status,
                c.submitted_at, c.completed_at
         FROM commands c
-        WHERE c.user_id = p_user_id AND c.id > p_since_id
+        WHERE c.user_id = p_user_id AND c.session_id = p_session_id
+          AND c.id > p_since_id
         ORDER BY c.id ASC;
     END IF;
 END;

--- a/sql/migrate_session_identity.sql
+++ b/sql/migrate_session_identity.sql
@@ -1,0 +1,58 @@
+-- Idempotently upgrade the original one-environment-per-user schema.
+-- Every legacy user environment becomes one session and all of that user's
+-- existing commands are attached to it.
+
+ALTER TABLE environments
+  ADD COLUMN IF NOT EXISTS session_id UUID DEFAULT gen_random_uuid();
+UPDATE environments SET session_id = gen_random_uuid() WHERE session_id IS NULL;
+ALTER TABLE environments ALTER COLUMN session_id SET NOT NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'environments'::regclass
+       AND contype = 'p'
+       AND conname = 'environments_pkey'
+       AND pg_get_constraintdef(oid) = 'PRIMARY KEY (user_id)'
+  ) THEN
+    ALTER TABLE environments DROP CONSTRAINT environments_pkey;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'environments'::regclass AND contype = 'p'
+  ) THEN
+    ALTER TABLE environments ADD CONSTRAINT environments_pkey PRIMARY KEY (session_id);
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS environments_session_user_idx
+  ON environments(session_id, user_id);
+CREATE INDEX IF NOT EXISTS environments_user_id_idx ON environments(user_id);
+
+ALTER TABLE commands ADD COLUMN IF NOT EXISTS session_id UUID;
+UPDATE commands c
+   SET session_id = e.session_id
+  FROM environments e
+ WHERE c.session_id IS NULL AND e.user_id = c.user_id;
+ALTER TABLE commands ALTER COLUMN session_id SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'commands'::regclass
+       AND conname = 'commands_session_owner_fkey'
+  ) THEN
+    ALTER TABLE commands ADD CONSTRAINT commands_session_owner_fkey
+      FOREIGN KEY (session_id, user_id)
+      REFERENCES environments(session_id, user_id);
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS commands_user_id_id_idx;
+DROP INDEX IF EXISTS commands_user_replay_source_idx;
+CREATE INDEX IF NOT EXISTS commands_session_id_id_idx ON commands(session_id, id);
+CREATE INDEX IF NOT EXISTS commands_session_replay_source_idx
+  ON commands(session_id, replay_of_command_id)
+  WHERE replay_of_command_id IS NOT NULL;

--- a/sql/replay_session.sql
+++ b/sql/replay_session.sql
@@ -10,8 +10,11 @@
 -- replaying a range which already contains prior replays cannot snowball.
 -- Returns the replay_run_id grouping the newly queued commands.
 
+DROP FUNCTION IF EXISTS replay_session(UUID, INTEGER);
+
 CREATE OR REPLACE FUNCTION replay_session(
   p_user_id UUID,
+  p_session_id UUID,
   p_start_id INTEGER
 )
 RETURNS UUID LANGUAGE plpgsql AS $$
@@ -26,15 +29,23 @@ BEGIN
       USING ERRCODE = '22023';
   END IF;
 
+  PERFORM 1 FROM environments
+   WHERE session_id = p_session_id AND user_id = p_user_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Unknown session_id or session not owned by user: %', p_session_id
+      USING ERRCODE = '22023';
+  END IF;
+
   FOR rec IN
     SELECT id, command
       FROM commands
      WHERE user_id = p_user_id
+       AND session_id = p_session_id
        AND id >= p_start_id
        AND replay_of_command_id IS NULL
      ORDER BY id ASC
   LOOP
-    PERFORM submit_command(p_user_id, rec.command, rec.id, run_id);
+    PERFORM submit_command(p_user_id, p_session_id, rec.command, rec.id, run_id);
   END LOOP;
 
   RETURN run_id;

--- a/sql/submit_command.sql
+++ b/sql/submit_command.sql
@@ -1,8 +1,12 @@
 -- submit_command: queues a command for execution
 -- References SPEC.md (RPC function); consumed by workers/executor_agent.py
 
+DROP FUNCTION IF EXISTS submit_command(UUID, TEXT);
+DROP FUNCTION IF EXISTS submit_command(UUID, TEXT, INT, UUID);
+
 CREATE OR REPLACE FUNCTION submit_command(
   p_user_id UUID,
+  p_session_id UUID,
   p_command TEXT,
   p_replay_of_command_id INT DEFAULT NULL,
   p_replay_run_id UUID DEFAULT NULL
@@ -21,15 +25,17 @@ BEGIN
       USING ERRCODE = '22023';
   END IF;
 
-  -- ensure environment row exists
-  SELECT * INTO env_row FROM environments WHERE user_id = p_user_id;
+  -- A session is explicit and must belong to the requesting user.
+  SELECT * INTO env_row FROM environments
+   WHERE session_id = p_session_id AND user_id = p_user_id;
   IF NOT FOUND THEN
-    INSERT INTO environments(user_id) VALUES (p_user_id)
-      RETURNING * INTO env_row;
+    RAISE EXCEPTION 'Unknown session_id or session not owned by user: %', p_session_id
+      USING ERRCODE = '22023';
   END IF;
 
   INSERT INTO commands(
     user_id,
+    session_id,
     command,
     cwd_snapshot,
     env_snapshot,
@@ -38,6 +44,7 @@ BEGIN
   )
     VALUES (
       p_user_id,
+      p_session_id,
       p_command,
       env_row.cwd,
       env_row.env,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import pytest
 # dependency order.
 SQL_FILES = (
     "sql/init_schema.sql",
+    "sql/migrate_session_identity.sql",
     "sql/submit_command.sql",
     "sql/latest_output.sql",
     "sql/fork_session.sql",

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -100,6 +100,7 @@ def test_handle_command_uses_combined_output(monkeypatch):
     row = {
         'id': 42,
         'user_id': 'u1',
+        'session_id': 's1',
         'command': 'ls',
         'cwd_snapshot': '.',
         'env_snapshot': None,
@@ -115,7 +116,7 @@ def test_handle_command_uses_combined_output(monkeypatch):
 def test_handle_command_cd_relative_within_root_succeeds(tmp_path, monkeypatch):
     captured: dict = {}
 
-    def fake_update_cwd(conn, user_id, cwd):
+    def fake_update_cwd(conn, user_id, session_id, cwd):
         captured['cwd'] = cwd
 
     def fake_update_command(conn, cmd_id, status, output, exit_code):
@@ -137,6 +138,7 @@ def test_handle_command_cd_relative_within_root_succeeds(tmp_path, monkeypatch):
     row = {
         'id': 1,
         'user_id': 'u1',
+        'session_id': 's1',
         'command': 'cd sub',
         'cwd_snapshot': str(tmp_path),
         'env_snapshot': None,
@@ -173,6 +175,7 @@ def test_handle_command_cd_nonexistent_path(tmp_path, monkeypatch):
     row = {
         'id': 2,
         'user_id': 'u1',
+        'session_id': 's1',
         'command': 'cd missing',
         'cwd_snapshot': str(tmp_path),
         'env_snapshot': None,
@@ -207,6 +210,7 @@ def test_handle_command_cd_dotdot_escaping_root_fails(tmp_path, monkeypatch):
     row = {
         'id': 5,
         'user_id': 'u1',
+        'session_id': 's1',
         'command': 'cd ..',
         'cwd_snapshot': str(tmp_path),
         'env_snapshot': None,
@@ -241,6 +245,7 @@ def test_handle_command_cd_absolute_outside_root_fails(tmp_path, monkeypatch):
     row = {
         'id': 6,
         'user_id': 'u1',
+        'session_id': 's1',
         'command': 'cd /tmp',
         'cwd_snapshot': str(tmp_path),
         'env_snapshot': None,
@@ -275,6 +280,7 @@ def test_handle_command_cd_with_extra_args_runs_subprocess(monkeypatch):
     row = {
         'id': 3,
         'user_id': 'u1',
+        'session_id': 's1',
         'command': 'cd /tmp extra',
         'cwd_snapshot': '.',
         'env_snapshot': None,
@@ -308,6 +314,7 @@ def test_handle_command_malformed_command(monkeypatch):
     row = {
         'id': 4,
         'user_id': 'u1',
+        'session_id': 's1',
         'command': 'echo "unterminated',
         'cwd_snapshot': '.',
         'env_snapshot': None,
@@ -333,6 +340,7 @@ def test_handle_command_missing_binary_marks_failed(monkeypatch, tmp_path):
     row = {
         'id': 7,
         'user_id': 'u1',
+        'session_id': 's1',
         'command': 'definitely_not_a_real_binary_xyz',
         'cwd_snapshot': str(tmp_path),
         'env_snapshot': None,

--- a/tests/test_executor_integration.py
+++ b/tests/test_executor_integration.py
@@ -13,7 +13,7 @@ import psycopg2
 from workers.executor_agent import fetch_pending, handle_command
 
 
-def _create_user_with_env(conn, cwd: str) -> str:
+def _create_user_with_env(conn, cwd: str) -> tuple[str, str]:
     user_id = str(uuid.uuid4())
     with conn.cursor() as cur:
         cur.execute(
@@ -21,16 +21,17 @@ def _create_user_with_env(conn, cwd: str) -> str:
             (user_id, f"exec-{user_id[:8]}"),
         )
         cur.execute(
-            "INSERT INTO environments(user_id, cwd) VALUES (%s, %s)",
+            "INSERT INTO environments(user_id, cwd) VALUES (%s, %s) RETURNING session_id",
             (user_id, cwd),
         )
-    return user_id
+        session_id = str(cur.fetchone()[0])
+    return user_id, session_id
 
 
 def test_executor_runs_pending_command_end_to_end(db_conn):
-    user_id = _create_user_with_env(db_conn, "/tmp")
+    user_id, session_id = _create_user_with_env(db_conn, "/tmp")
     with db_conn.cursor() as cur:
-        cur.execute("SELECT submit_command(%s, %s)", (user_id, "echo integration-ok"))
+        cur.execute("SELECT submit_command(%s, %s, %s)", (user_id, session_id, "echo integration-ok"))
         cmd_id = cur.fetchone()[0]
 
     # fetch_pending claims the row and flips it to 'running'.
@@ -61,9 +62,9 @@ def test_executor_cd_updates_environment(db_conn, monkeypatch, tmp_path):
     sub.mkdir()
     monkeypatch.setenv("SHELL_ROOT", str(tmp_path))
 
-    user_id = _create_user_with_env(db_conn, str(tmp_path))
+    user_id, session_id = _create_user_with_env(db_conn, str(tmp_path))
     with db_conn.cursor() as cur:
-        cur.execute("SELECT submit_command(%s, %s)", (user_id, "cd workdir"))
+        cur.execute("SELECT submit_command(%s, %s, %s)", (user_id, session_id, "cd workdir"))
         cmd_id = cur.fetchone()[0]
 
     db_conn.autocommit = False
@@ -77,7 +78,7 @@ def test_executor_cd_updates_environment(db_conn, monkeypatch, tmp_path):
     with db_conn.cursor() as cur:
         cur.execute("SELECT status FROM commands WHERE id = %s", (cmd_id,))
         assert cur.fetchone()[0] == "done"
-        cur.execute("SELECT cwd FROM environments WHERE user_id = %s", (user_id,))
+        cur.execute("SELECT cwd FROM environments WHERE session_id = %s", (session_id,))
         assert cur.fetchone()[0] == str(sub)
 
 
@@ -97,11 +98,11 @@ def test_queued_commands_use_sequential_per_user_environment(
     child = tmp_path / "child"
     child.mkdir()
     monkeypatch.setenv("SHELL_ROOT", str(tmp_path))
-    user_id = _create_user_with_env(db_conn, str(tmp_path))
+    user_id, session_id = _create_user_with_env(db_conn, str(tmp_path))
     with db_conn.cursor() as cur:
-        cur.execute("SELECT submit_command(%s, %s)", (user_id, "cd child"))
+        cur.execute("SELECT submit_command(%s, %s, %s)", (user_id, session_id, "cd child"))
         cd_id = cur.fetchone()[0]
-        cur.execute("SELECT submit_command(%s, %s)", (user_id, "pwd"))
+        cur.execute("SELECT submit_command(%s, %s, %s)", (user_id, session_id, "pwd"))
         pwd_id = cur.fetchone()[0]
 
     worker_one = psycopg2.connect(db_conn.dsn)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -59,6 +59,14 @@ def _fetch_plan_root(cur):
     return raw["Plan"]
 
 
+def _create_session(cur, user_id):
+    cur.execute(
+        "INSERT INTO environments(user_id) VALUES (%s) RETURNING session_id",
+        (user_id,),
+    )
+    return cur.fetchone()[0]
+
+
 @pytest.fixture(scope="module")
 def conn():
     dsn = os.environ.get("TEST_DATABASE_URL")
@@ -85,9 +93,10 @@ def test_submit_and_latest_output(conn):
     user_id = str(uuid.uuid4())
     with conn.cursor() as cur:
         cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (user_id, "testuser"))
+        session_id = _create_session(cur, user_id)
         cmd_ids = []
         for idx in range(25):
-            cur.execute("SELECT submit_command(%s, %s)", (user_id, f"echo msg{idx}"))
+            cur.execute("SELECT submit_command(%s, %s, %s)", (user_id, session_id, f"echo msg{idx}"))
             cmd_id = cur.fetchone()[0]
             cur.execute(
                 "UPDATE commands SET output=%s, exit_code=0, status='done', completed_at=now() WHERE id=%s",
@@ -95,7 +104,7 @@ def test_submit_and_latest_output(conn):
             )
             cmd_ids.append(cmd_id)
 
-        cur.execute("SELECT * FROM latest_output(%s)", (user_id,))
+        cur.execute("SELECT * FROM latest_output(%s, %s)", (user_id, session_id))
         rows = cur.fetchall()
 
         assert len(rows) == 20
@@ -109,10 +118,11 @@ def test_submit_command_notifies(conn):
     user_id = str(uuid.uuid4())
     with conn.cursor() as cur:
         cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (user_id, "notify"))
+        session_id = _create_session(cur, user_id)
         cur.execute("LISTEN new_command;")
     conn.notifies.clear()
     with conn.cursor() as cur:
-        cur.execute("SELECT submit_command(%s, %s)", (user_id, "echo ping"))
+        cur.execute("SELECT submit_command(%s, %s, %s)", (user_id, session_id, "echo ping"))
         cmd_id = cur.fetchone()[0]
     notification = wait_for_notification(conn)
     with conn.cursor() as cur:
@@ -127,6 +137,7 @@ def test_submit_command_respects_configured_channel(conn):
     alt_channel = 'custom_command_channel'
     with conn.cursor() as cur:
         cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (user_id, "config"))
+        session_id = _create_session(cur, user_id)
         cur.execute(
             """
             INSERT INTO pg_shell_config(key, value)
@@ -139,7 +150,7 @@ def test_submit_command_respects_configured_channel(conn):
         cur.execute(sql.SQL("LISTEN {}").format(sql.Identifier(alt_channel)))
     conn.notifies.clear()
     with conn.cursor() as cur:
-        cur.execute("SELECT submit_command(%s, %s)", (user_id, "echo config"))
+        cur.execute("SELECT submit_command(%s, %s, %s)", (user_id, session_id, "echo config"))
         cmd_id = cur.fetchone()[0]
     notification = wait_for_notification(conn)
     with conn.cursor() as cur:
@@ -155,32 +166,58 @@ def test_submit_command_requires_existing_user(conn):
     missing_user_id = str(uuid.uuid4())
     with conn.cursor() as cur:
         with pytest.raises(psycopg2.Error) as exc_info:
-            cur.execute("SELECT submit_command(%s, %s)", (missing_user_id, "echo nope"))
+            cur.execute("SELECT submit_command(%s, %s, %s)", (missing_user_id, uuid.uuid4(), "echo nope"))
     err = exc_info.value
     assert "Unknown user_id" in str(err)
     assert err.pgcode == '22023'
 
 
-def test_fork_session_same_user_source_command_succeeds(conn):
+def test_fork_session_creates_independent_session_without_changing_source(conn):
     user_id = str(uuid.uuid4())
     with conn.cursor() as cur:
         cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (user_id, "u2"))
         cur.execute(
-            "INSERT INTO environments(user_id, cwd, env) VALUES (%s, %s, %s)",
-            (user_id, '/home/start', '{"FOO":"BAR"}'),
+            """INSERT INTO environments(user_id, cwd, env)
+                 VALUES (%s, %s, %s) RETURNING session_id""",
+            (user_id, '/home/source-current', '{"LIVE":"YES"}'),
         )
-        cur.execute("SELECT submit_command(%s, %s)", (user_id, "ls"))
+        source_session_id = cur.fetchone()[0]
+        cur.execute(
+            "SELECT submit_command(%s, %s, %s)",
+            (user_id, source_session_id, "ls"),
+        )
         cmd_id = cur.fetchone()[0]
         cur.execute(
             "UPDATE commands SET cwd_snapshot=%s, env_snapshot=%s::jsonb WHERE id=%s",
             ('/home/start', '{"FOO":"BAR"}', cmd_id),
         )
         cur.execute("SELECT fork_session(%s, %s)", (user_id, cmd_id))
-        cur.fetchone()
-        cur.execute("SELECT cwd, env FROM environments WHERE user_id=%s", (user_id,))
-        cwd, env = cur.fetchone()
-        assert cwd == '/home/start'
-        assert env == {"FOO": "BAR"}
+        fork_session_id = cur.fetchone()[0]
+        assert fork_session_id != source_session_id
+
+        cur.execute(
+            "SELECT cwd, env FROM environments WHERE session_id=%s",
+            (source_session_id,),
+        )
+        assert cur.fetchone() == ('/home/source-current', {"LIVE": "YES"})
+        cur.execute(
+            "SELECT cwd, env FROM environments WHERE session_id=%s",
+            (fork_session_id,),
+        )
+        assert cur.fetchone() == ('/home/start', {"FOO": "BAR"})
+
+        # Commands submitted to the fork use its state and do not affect the
+        # source session's command stream.
+        cur.execute(
+            "SELECT submit_command(%s, %s, %s)",
+            (user_id, fork_session_id, "pwd"),
+        )
+        fork_command_id = cur.fetchone()[0]
+        cur.execute(
+            "SELECT session_id, cwd_snapshot FROM commands WHERE id=%s",
+            (fork_command_id,),
+        )
+        assert cur.fetchone() == (fork_session_id, '/home/start')
 
 
 def test_fork_session_different_user_source_command_fails(conn):
@@ -195,7 +232,15 @@ def test_fork_session_different_user_source_command_fails(conn):
             "INSERT INTO users(id, username) VALUES (%s, %s)",
             (target_user_id, "fork-dst"),
         )
-        cur.execute("SELECT submit_command(%s, %s)", (source_user_id, "pwd"))
+        cur.execute(
+            "INSERT INTO environments(user_id) VALUES (%s) RETURNING session_id",
+            (source_user_id,),
+        )
+        source_session_id = cur.fetchone()[0]
+        cur.execute(
+            "SELECT submit_command(%s, %s, %s)",
+            (source_user_id, source_session_id, "pwd"),
+        )
         source_cmd_id = cur.fetchone()[0]
         cur.execute(
             "UPDATE commands SET cwd_snapshot=%s, env_snapshot=%s::jsonb WHERE id=%s",
@@ -210,9 +255,10 @@ def test_latest_output_since_id(conn):
     user_id = str(uuid.uuid4())
     with conn.cursor() as cur:
         cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (user_id, "u3"))
+        session_id = _create_session(cur, user_id)
         ids = []
         for idx in range(25):
-            cur.execute("SELECT submit_command(%s, %s)", (user_id, f"echo seq{idx}"))
+            cur.execute("SELECT submit_command(%s, %s, %s)", (user_id, session_id, f"echo seq{idx}"))
             cmd_id = cur.fetchone()[0]
             cur.execute(
                 "UPDATE commands SET output=%s, exit_code=0, status='done', completed_at=now() WHERE id=%s",
@@ -221,7 +267,7 @@ def test_latest_output_since_id(conn):
             ids.append(cmd_id)
 
         since_id = ids[4]
-        cur.execute("SELECT * FROM latest_output(%s, %s)", (user_id, since_id))
+        cur.execute("SELECT * FROM latest_output(%s, %s, %s)", (user_id, session_id, since_id))
         rows = cur.fetchall()
 
         expected_ids = ids[5:]
@@ -233,13 +279,14 @@ def test_replay_session_requeues_from_start(conn):
     user_id = str(uuid.uuid4())
     with conn.cursor() as cur:
         cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (user_id, "replayer"))
+        session_id = _create_session(cur, user_id)
         original_ids = []
         for idx in range(3):
-            cur.execute("SELECT submit_command(%s, %s)", (user_id, f"echo r{idx}"))
+            cur.execute("SELECT submit_command(%s, %s, %s)", (user_id, session_id, f"echo r{idx}"))
             original_ids.append(cur.fetchone()[0])
 
         start_id = original_ids[1]
-        cur.execute("SELECT replay_session(%s, %s)", (user_id, start_id))
+        cur.execute("SELECT replay_session(%s, %s, %s)", (user_id, session_id, start_id))
         run_id = cur.fetchone()[0]
         assert run_id is not None
 
@@ -266,16 +313,17 @@ def test_replay_session_only_replays_originals(conn):
     user_id = str(uuid.uuid4())
     with conn.cursor() as cur:
         cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (user_id, "replayer2"))
-        cur.execute("SELECT submit_command(%s, %s)", (user_id, "echo once"))
+        session_id = _create_session(cur, user_id)
+        cur.execute("SELECT submit_command(%s, %s, %s)", (user_id, session_id, "echo once"))
         original_id = cur.fetchone()[0]
 
         # First replay creates one replayed row.
-        cur.execute("SELECT replay_session(%s, %s)", (user_id, original_id))
+        cur.execute("SELECT replay_session(%s, %s, %s)", (user_id, session_id, original_id))
         cur.fetchone()
 
         # Second replay from the same start must re-queue only the original,
         # not the row produced by the first replay.
-        cur.execute("SELECT replay_session(%s, %s)", (user_id, original_id))
+        cur.execute("SELECT replay_session(%s, %s, %s)", (user_id, session_id, original_id))
         second_run = cur.fetchone()[0]
 
         cur.execute(
@@ -292,7 +340,7 @@ def test_replay_session_unknown_user_raises(conn):
     missing_user = str(uuid.uuid4())
     with conn.cursor() as cur:
         with pytest.raises(psycopg2.Error) as exc_info:
-            cur.execute("SELECT replay_session(%s, %s)", (missing_user, 1))
+            cur.execute("SELECT replay_session(%s, %s, %s)", (missing_user, uuid.uuid4(), 1))
     assert exc_info.value.pgcode == "22023"
 
 
@@ -302,19 +350,21 @@ def test_command_indexes_query_plans(conn):
     with conn.cursor() as cur:
         cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (primary_user, "planner"))
         cur.execute("INSERT INTO users(id, username) VALUES (%s, %s)", (secondary_user, "other"))
+        primary_session = _create_session(cur, primary_user)
+        secondary_session = _create_session(cur, secondary_user)
 
         # Populate enough data to give the planner a strong preference for the new indexes
         for i in range(50):
             cur.execute(
-                "INSERT INTO commands(user_id, command, status, submitted_at)"
-                " VALUES (%s, %s, %s, now() - (%s * INTERVAL '1 minute'))",
-                (primary_user, f'cmd {i}', 'pending' if i % 3 else 'done', i),
+                "INSERT INTO commands(user_id, session_id, command, status, submitted_at)"
+                " VALUES (%s, %s, %s, %s, now() - (%s * INTERVAL '1 minute'))",
+                (primary_user, primary_session, f'cmd {i}', 'pending' if i % 3 else 'done', i),
             )
         for i in range(10):
             cur.execute(
-                "INSERT INTO commands(user_id, command, status, submitted_at)"
-                " VALUES (%s, %s, %s, now() - (%s * INTERVAL '1 minute'))",
-                (secondary_user, f'spare {i}', 'pending', i),
+                "INSERT INTO commands(user_id, session_id, command, status, submitted_at)"
+                " VALUES (%s, %s, %s, %s, now() - (%s * INTERVAL '1 minute'))",
+                (secondary_user, secondary_session, f'spare {i}', 'pending', i),
             )
 
         # Refresh planner statistics so index selection reflects the data we
@@ -332,9 +382,9 @@ def test_command_indexes_query_plans(conn):
 
         cur.execute(
             "EXPLAIN (FORMAT JSON) "
-            "SELECT id FROM commands WHERE user_id = %s ORDER BY id DESC LIMIT 1",
-            (primary_user,),
+            "SELECT id FROM commands WHERE session_id = %s ORDER BY id DESC LIMIT 1",
+            (primary_session,),
         )
         latest_plan = _fetch_plan_root(cur)
         latest_indexes = _collect_index_names(latest_plan)
-        assert "commands_user_id_id_idx" in latest_indexes
+        assert "commands_session_id_id_idx" in latest_indexes

--- a/tests/test_postgrest_integration.py
+++ b/tests/test_postgrest_integration.py
@@ -20,7 +20,9 @@ def test_tail_output_invokes_latest_output_through_postgrest(db_conn, capsys):
             "INSERT INTO users(id, username) VALUES (%s, %s)",
             (user_id, f"postgrest-{user_id}"),
         )
-        cur.execute("SELECT submit_command(%s, %s)", (user_id, "echo integration"))
+        cur.execute("INSERT INTO environments(user_id) VALUES (%s) RETURNING session_id", (user_id,))
+        session_id = str(cur.fetchone()[0])
+        cur.execute("SELECT submit_command(%s, %s, %s)", (user_id, session_id, "echo integration"))
         command_id = cur.fetchone()[0]
         cur.execute(
             """
@@ -33,7 +35,7 @@ def test_tail_output_invokes_latest_output_through_postgrest(db_conn, capsys):
         )
 
     assert tail_output(
-        base_url.rstrip("/"), user_id, since=0, interval=0, max_polls=1
+        base_url.rstrip("/"), user_id, session_id, since=0, interval=0, max_polls=1
     ) == 0
     assert capsys.readouterr().out.splitlines() == [
         "$ echo integration",

--- a/tests/test_replay_agent.py
+++ b/tests/test_replay_agent.py
@@ -53,7 +53,7 @@ class FakeSubmitCursor:
         self.execute_calls.append((query, params))
         if "FROM commands" in query and "replay_of_command_id" in query:
             self._last_exists = (
-                1 if params and params[1] in self.already_replayed else None
+                1 if params and params[2] in self.already_replayed else None
             )
         else:
             self._last_exists = "submit"
@@ -108,7 +108,7 @@ class FakeConnFactory:
 
 
 def test_main_returns_zero_after_successful_replay(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["replay_agent.py", "--user", "u1", "--start", "1"])
+    monkeypatch.setattr(sys, "argv", ["replay_agent.py", "--user", "u1", "--session", "s1", "--start", "1"])
     monkeypatch.setattr(replay_agent, "replay_commands", lambda *args, **kwargs: None)
 
     assert replay_agent.main() == 0
@@ -133,7 +133,7 @@ def test_main_returns_nonzero_for_invalid_option(monkeypatch):
 
 
 def test_main_returns_nonzero_for_connection_failure(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["replay_agent.py", "--user", "u1", "--start", "1"])
+    monkeypatch.setattr(sys, "argv", ["replay_agent.py", "--user", "u1", "--session", "s1", "--start", "1"])
 
     def fail_to_connect(*args, **kwargs):
         raise RuntimeError("connection unavailable")
@@ -144,7 +144,7 @@ def test_main_returns_nonzero_for_connection_failure(monkeypatch):
 
 
 def test_main_returns_nonzero_for_database_operation_failure(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["replay_agent.py", "--user", "u1", "--start", "1"])
+    monkeypatch.setattr(sys, "argv", ["replay_agent.py", "--user", "u1", "--session", "s1", "--start", "1"])
 
     def fail_database_operation(*args, **kwargs):
         raise psycopg2.DatabaseError("query failed")
@@ -161,7 +161,7 @@ def test_replay_commands_no_commands_logs_message(monkeypatch, caplog):
         replay_agent, "get_conn", FakeConnFactory(history_conn, submit_conn)
     )
     with caplog.at_level(logging.INFO):
-        replay_agent.replay_commands("u1", 1)
+        replay_agent.replay_commands("u1", "s1", 1)
     assert "no commands to replay" in caplog.text
     assert submit_conn.commit_count == 0
     assert len(history_conn.cursor_obj.fetchmany_calls) == 1
@@ -174,7 +174,7 @@ def test_replay_commands_streams_large_command_set(monkeypatch):
     monkeypatch.setattr(
         replay_agent, "get_conn", FakeConnFactory(history_conn, submit_conn)
     )
-    replay_agent.replay_commands("u1", 1)
+    replay_agent.replay_commands("u1", "s1", 1)
     assert submit_conn.commit_count == math.ceil(len(rows) / 100)
     expected_calls = math.ceil(len(rows) / 100) + 1
     assert len(history_conn.cursor_obj.fetchmany_calls) == expected_calls
@@ -187,13 +187,13 @@ def test_replay_commands_replays_full_history(monkeypatch):
     monkeypatch.setattr(
         replay_agent, "get_conn", FakeConnFactory(history_conn, submit_conn)
     )
-    replay_agent.replay_commands("u1", 1)
+    replay_agent.replay_commands("u1", "s1", 1)
     assert len(submit_conn.cursor_obj.execute_calls) == len(rows)
     submitted_commands = [params for _, params in submit_conn.cursor_obj.execute_calls]
-    assert submitted_commands[0][0:2] == ("u1", "cmd0")
-    assert submitted_commands[-1][0:2] == ("u1", "cmd149")
-    assert submitted_commands[0][2] == 0
-    assert submitted_commands[-1][2] == 149
+    assert submitted_commands[0][0:3] == ("u1", "s1", "cmd0")
+    assert submitted_commands[-1][0:3] == ("u1", "s1", "cmd149")
+    assert submitted_commands[0][3] == 0
+    assert submitted_commands[-1][3] == 149
 
 
 def test_replay_commands_resume_skips_already_replayed(monkeypatch):
@@ -204,7 +204,7 @@ def test_replay_commands_resume_skips_already_replayed(monkeypatch):
         replay_agent, "get_conn", FakeConnFactory(history_conn, submit_conn)
     )
 
-    replay_agent.replay_commands("u1", 1, resume=True)
+    replay_agent.replay_commands("u1", "s1", 1, resume=True)
 
     submit_calls = [
         call
@@ -225,7 +225,7 @@ def test_replay_commands_first_run_then_resume_enqueues_zero_new_rows(monkeypatc
         "get_conn",
         FakeConnFactory(first_history_conn, first_submit_conn),
     )
-    replay_agent.replay_commands("u1", 1, resume=True)
+    replay_agent.replay_commands("u1", "s1", 1, resume=True)
     first_submit_calls = [
         params
         for query, params in first_submit_conn.cursor_obj.execute_calls
@@ -240,7 +240,7 @@ def test_replay_commands_first_run_then_resume_enqueues_zero_new_rows(monkeypatc
         "get_conn",
         FakeConnFactory(second_history_conn, second_submit_conn),
     )
-    replay_agent.replay_commands("u1", 1, resume=True)
+    replay_agent.replay_commands("u1", "s1", 1, resume=True)
     second_submit_calls = [
         params
         for query, params in second_submit_conn.cursor_obj.execute_calls
@@ -260,7 +260,7 @@ def _mixed_history():
 
 def _submitted_source_ids(submit_conn):
     return [
-        params[2]
+        params[3]
         for query, params in submit_conn.cursor_obj.execute_calls
         if query.strip().startswith("SELECT submit_command")
     ]
@@ -273,7 +273,7 @@ def test_replay_commands_only_submits_original_commands(monkeypatch):
         replay_agent, "get_conn", FakeConnFactory(history_conn, submit_conn)
     )
 
-    replay_agent.replay_commands("u1", 1)
+    replay_agent.replay_commands("u1", "s1", 1)
 
     assert _submitted_source_ids(submit_conn) == [1, 3]
 
@@ -285,11 +285,11 @@ def test_replay_commands_resume_only_checks_and_submits_originals(monkeypatch):
         replay_agent, "get_conn", FakeConnFactory(history_conn, submit_conn)
     )
 
-    replay_agent.replay_commands("u1", 1, resume=True)
+    replay_agent.replay_commands("u1", "s1", 1, resume=True)
 
     assert _submitted_source_ids(submit_conn) == [3]
     resume_source_ids = [
-        params[1]
+        params[2]
         for query, params in submit_conn.cursor_obj.execute_calls
         if "FROM commands" in query
     ]
@@ -305,7 +305,7 @@ def test_replay_commands_force_duplicates_originals_without_replaying_generated_
         replay_agent, "get_conn", FakeConnFactory(history_conn, submit_conn)
     )
 
-    replay_agent.replay_commands("u1", 1, force=True)
+    replay_agent.replay_commands("u1", "s1", 1, force=True)
 
     assert _submitted_source_ids(submit_conn) == [1, 3]
     assert all(

--- a/tests/test_shell_cli.py
+++ b/tests/test_shell_cli.py
@@ -17,7 +17,7 @@ def test_exec_command_posts_with_prefer_headers(monkeypatch, capsys):
         assert url == "http://example/rpc/submit_command"
         # PostgREST maps JSON body keys to function argument names, so the
         # keys must match submit_command(p_user_id, p_command).
-        assert json == {"p_user_id": "u1", "p_command": "ls"}
+        assert json == {"p_user_id": "u1", "p_session_id": "s1", "p_command": "ls"}
         assert timeout == 5
         assert headers["Prefer"] == "return=representation"
         assert headers["Accept"] == "application/json"
@@ -25,7 +25,7 @@ def test_exec_command_posts_with_prefer_headers(monkeypatch, capsys):
 
     monkeypatch.setattr(sc.requests, "post", fake_post)
 
-    rc = sc.exec_command("http://example", "u1", "ls", timeout=5)
+    rc = sc.exec_command("http://example", "u1", "s1", "ls", timeout=5)
     assert rc == 0
     captured = capsys.readouterr()
     assert captured.out.strip() == "{'status': 'ok'}"
@@ -68,28 +68,28 @@ def test_replay_session_posts_prefixed_arguments(monkeypatch, capsys):
 
     def fake_post(url, json, timeout, headers):
         assert url == "http://example/rpc/replay_session"
-        assert json == {"p_user_id": "u1", "p_start_id": 5}
+        assert json == {"p_user_id": "u1", "p_session_id": "s1", "p_start_id": 5}
         return Resp()
 
     monkeypatch.setattr(sc.requests, "post", fake_post)
 
-    rc = sc.replay_session("http://example", "u1", 5)
+    rc = sc.replay_session("http://example", "u1", "s1", 5)
     assert rc == 0
 
 
 def test_main_replay_dispatches_user_and_start(monkeypatch):
     captured = {}
 
-    def fake_replay(base_url, user_id, start_id, timeout):
-        captured["args"] = (base_url, user_id, start_id)
+    def fake_replay(base_url, user_id, session_id, start_id, timeout):
+        captured["args"] = (base_url, user_id, session_id, start_id)
         return 0
 
     monkeypatch.setattr(sc, "replay_session", fake_replay)
     rc = sc.main(
-        ["--base-url", "http://example", "replay", "--user", "u1", "--start", "5"]
+        ["--base-url", "http://example", "replay", "--user", "u1", "--session", "s1", "--start", "5"]
     )
     assert rc == 0
-    assert captured["args"] == ("http://example", "u1", 5)
+    assert captured["args"] == ("http://example", "u1", "s1", 5)
 
 
 def test_exec_command_handles_empty_response(monkeypatch, capsys):
@@ -110,7 +110,7 @@ def test_exec_command_handles_empty_response(monkeypatch, capsys):
         lambda *args, **kwargs: Resp(),
     )
 
-    rc = sc.exec_command("http://example", "u1", "ls")
+    rc = sc.exec_command("http://example", "u1", "s1", "ls")
     assert rc == 0
     captured = capsys.readouterr()
     assert captured.out.strip() == "204 No Content"
@@ -131,7 +131,7 @@ def test_tail_output_stops_after_max_polls(monkeypatch):
     monkeypatch.setattr(sc.requests, 'get', fake_get)
     monkeypatch.setattr(sc.time, 'sleep', lambda _: None)
 
-    rc = sc.tail_output('http://example', 'u1', interval=0, max_polls=2)
+    rc = sc.tail_output('http://example', 'u1', 's1', interval=0, max_polls=2)
     assert rc == 0
     assert len(calls) == 2
 
@@ -151,7 +151,7 @@ def test_tail_output_prints_text_when_json_missing(monkeypatch, capsys):
     monkeypatch.setattr(sc.requests, 'get', lambda *args, **kwargs: Resp())
     monkeypatch.setattr(sc.time, 'sleep', lambda _: None)
 
-    rc = sc.tail_output('http://example', 'u1', interval=0, max_polls=1)
+    rc = sc.tail_output('http://example', 'u1', 's1', interval=0, max_polls=1)
     assert rc == 0
     captured = capsys.readouterr()
     assert captured.out.strip() == 'plain text'
@@ -198,7 +198,7 @@ def test_tail_output_waits_for_terminal_status(monkeypatch, capsys):
     monkeypatch.setattr(sc.requests, 'get', fake_get)
     monkeypatch.setattr(sc.time, 'sleep', lambda _: None)
 
-    rc = sc.tail_output('http://example', 'u1', interval=0, max_polls=3)
+    rc = sc.tail_output('http://example', 'u1', 's1', interval=0, max_polls=3)
     assert rc == 0
 
     captured = capsys.readouterr()
@@ -209,7 +209,7 @@ def test_tail_output_waits_for_terminal_status(monkeypatch, capsys):
     ]
 
     assert call_params == [
-        {'p_user_id': 'u1'},
-        {'p_user_id': 'u1'},
-        {'p_user_id': 'u1', 'p_since_id': 1},
+        {'p_user_id': 'u1', 'p_session_id': 's1'},
+        {'p_user_id': 'u1', 'p_session_id': 's1'},
+        {'p_user_id': 'u1', 'p_session_id': 's1', 'p_since_id': 1},
     ]

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -100,7 +100,7 @@ def wait_for_notify(conn, timeout: float) -> None:
 
 
 def fetch_pending(conn) -> Dict[str, Any] | None:
-    """Claim the next command while holding a session-level per-user lock.
+    """Claim the next command while holding a session-level session lock.
 
     The advisory lock remains held after this function commits and is released
     by :func:`handle_command`.  Consequently another executor connection cannot
@@ -111,15 +111,16 @@ def fetch_pending(conn) -> Dict[str, Any] | None:
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute("BEGIN;")
         cur.execute("""
-            SELECT c.id, c.user_id, c.command, e.cwd, e.env,
-                   hashtextextended(c.user_id::text, 0) AS claim_lock_key
+            SELECT c.id, c.user_id, c.session_id, c.command, e.cwd, e.env,
+                   hashtextextended(c.session_id::text, 0) AS claim_lock_key
             FROM commands AS c
-            JOIN environments AS e ON e.user_id = c.user_id
+            JOIN environments AS e
+              ON e.session_id = c.session_id AND e.user_id = c.user_id
             WHERE c.status = 'pending'
               AND NOT EXISTS (
                     SELECT 1
                     FROM commands AS earlier
-                    WHERE earlier.user_id = c.user_id
+                    WHERE earlier.session_id = c.session_id
                       AND earlier.status IN ('pending', 'running')
                       AND (earlier.submitted_at, earlier.id)
                           < (c.submitted_at, c.id)
@@ -158,11 +159,12 @@ def update_command(conn, cmd_id: int, status: str, output: str, exit_code: int) 
     conn.commit()
 
 
-def update_cwd(conn, user_id, cwd: str) -> None:
+def update_cwd(conn, user_id, session_id, cwd: str) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "UPDATE environments SET cwd=%s, updated_at=now() WHERE user_id=%s",
-            (cwd, user_id),
+            """UPDATE environments SET cwd=%s, updated_at=now()
+                 WHERE user_id=%s AND session_id=%s""",
+            (cwd, user_id, session_id),
         )
     conn.commit()
 
@@ -334,7 +336,7 @@ def _handle_command(conn, row: Dict[str, Any]) -> None:
                 path,
             )
             return
-        update_cwd(conn, row["user_id"], new_cwd)
+        update_cwd(conn, row["user_id"], row["session_id"], new_cwd)
         update_command(conn, row["id"], "done", "", 0)
         logging.info("Command %s for user %s completed", row["id"], row["user_id"])
         return

--- a/workers/replay_agent.py
+++ b/workers/replay_agent.py
@@ -10,6 +10,7 @@ from workers.db import get_conn
 
 def replay_commands(
     user_id: str,
+    session_id: str,
     start_id: int,
     *,
     resume: bool = False,
@@ -26,11 +27,11 @@ def replay_commands(
                 """
                 SELECT id, command
                  FROM commands
-                 WHERE user_id = %s AND id >= %s
+                 WHERE user_id = %s AND session_id = %s AND id >= %s
                    AND replay_of_command_id IS NULL
               ORDER BY id ASC
                 """,
-                (user_id, start_id),
+                (user_id, session_id, start_id),
             )
             batch_size = 100
             total = 0
@@ -51,10 +52,11 @@ def replay_commands(
                                     SELECT 1
                                       FROM commands
                                      WHERE user_id = %s
+                                       AND session_id = %s
                                        AND replay_of_command_id = %s
                                      LIMIT 1
                                     """,
-                                    (user_id, cmd_id),
+                                    (user_id, session_id, cmd_id),
                                 )
                                 if submit_cur.fetchone() is not None:
                                     logging.info(
@@ -66,8 +68,8 @@ def replay_commands(
                                 "Replaying command %s: %s", cmd_id, command
                             )
                             submit_cur.execute(
-                                "SELECT submit_command(%s, %s, %s, %s)",
-                                (user_id, command, cmd_id, replay_run_id),
+                                "SELECT submit_command(%s, %s, %s, %s, %s)",
+                                (user_id, session_id, command, cmd_id, replay_run_id),
                             )
                             new_id = submit_cur.fetchone()[0]
                             pending_commits += 1
@@ -89,6 +91,7 @@ def replay_commands(
 def main() -> int:
     parser = argparse.ArgumentParser(description="Replay user commands")
     parser.add_argument("--user", required=True, help="User ID")
+    parser.add_argument("--session", required=True, help="Session ID")
     parser.add_argument(
         "--start", type=int, required=True, help="Starting command ID"
     )
@@ -118,6 +121,7 @@ def main() -> int:
     try:
         replay_commands(
             args.user,
+            args.session,
             args.start,
             resume=args.resume,
             force=args.force,


### PR DESCRIPTION
### Motivation

- Make session identity explicit so multiple independent sessions can coexist per user and commands are targeted to a concrete session rather than implicitly to a user-wide environment.  
- Ensure forks create independent session state from a historical command snapshot without mutating the source session, and make ownership checks explicit to avoid cross-user leaks.  

### Description

- Introduce `session_id` as a UUID primary key for `environments` and add `session_id` on `commands`, enforce a composite foreign key `(session_id, user_id) REFERENCES environments(session_id, user_id)`, and add session-oriented indexes.  
- Add an idempotent migration `sql/migrate_session_identity.sql` that backfills a session per legacy per-user environment, migrates existing commands to sessions, and installs the new foreign key and indexes.  
- Update `fork_session` to validate the source command belongs to the requesting user, create a new `session_id` + environment row populated from the selected command snapshot, and return that new session UUID without changing the source environment.  
- Require callers to supply an explicit `p_session_id` in `submit_command`, `latest_output`, and `replay_session`; update their SQL implementations to validate session ownership and filter/query by `session_id`.  
- Update the executor to claim and lock per-session work (advisory locks keyed by `session_id`), join `environments` by `(session_id, user_id)`, and pass `session_id` into `update_cwd`.  
- Propagate `session_id` through the CLI (`cli/shell_cli.py`) and browser UI (`html/index.html`) so HTTP RPC calls include `p_session_id`.  
- Update `workers/replay_agent.py` to replay only within the specified session and to submit requeued commands with the target session id.  
- Extend and adjust unit and integration tests to exercise the new flows, including a fork test that asserts the source environment is unchanged and that subsequent commands can target the new fork independently.  

### Testing

- Performed syntax/pack checks: `git diff --check` and `python -m compileall -q cli workers tests` (succeeded).  
- Ran the test suite with `pytest -q`; result: `46 passed, 21 skipped` (skips are for optional DB/PostgREST/Playwright integrations).  
- Verified new migration script `sql/migrate_session_identity.sql` is included in `sql/install.sql` and exercised by the test fixtures that re-install the schema.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cc80aee108328a785a73198975342)