### PR TITLE
Add renewable executor leases and abandoned-command recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ DATABASE_URL=postgresql://localhost/postgres python workers/executor_agent.py
 The executor agent will exit with an error if neither `DATABASE_URL` nor
 `PG_CONN` is set.
 Set `COMMAND_TIMEOUT` (seconds) to limit how long each command may run.
+Executors claim work with renewable leases. `COMMAND_LEASE_SECONDS` controls
+the lease lifetime (60 seconds by default), and
+`COMMAND_LEASE_REFRESH_SECONDS` controls the heartbeat interval. Set a stable,
+unique `EXECUTOR_WORKER_ID` for a singleton worker deployment to let its next
+instance immediately recover commands left by the previous instance at
+startup; otherwise a process-unique identifier is generated and abandoned
+work is recovered when its lease expires.
 Commands are parsed with `shlex.split` before execution, so quoting rules follow
 POSIX shells but features like glob expansion are not performed.
 

--- a/sql/init_schema.sql
+++ b/sql/init_schema.sql
@@ -26,6 +26,9 @@ CREATE TABLE IF NOT EXISTS commands (
   replay_run_id UUID,
   submitted_at TIMESTAMP NOT NULL DEFAULT now(),
   status TEXT NOT NULL DEFAULT 'pending',
+  claimed_at TIMESTAMP,
+  lease_expires_at TIMESTAMP,
+  worker_id TEXT,
   output TEXT,
   exit_code INT,
   cwd_snapshot TEXT,
@@ -56,6 +59,9 @@ ON CONFLICT (key) DO NOTHING;
 
 CREATE INDEX IF NOT EXISTS commands_status_submitted_at_idx
   ON commands (status, submitted_at);
+
+CREATE INDEX IF NOT EXISTS commands_running_lease_idx
+  ON commands (lease_expires_at) WHERE status = 'running';
 
 CREATE INDEX IF NOT EXISTS commands_status_completed_at_idx
   ON commands (status, completed_at, id);

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -2,6 +2,7 @@
 \i sql/init_schema.sql
 \i sql/migrate_session_identity.sql
 \i sql/migrate_replay_provenance_retention.sql
+\i sql/migrate_command_leases.sql
 \i sql/submit_command.sql
 \i sql/latest_output.sql -- updated latest_output with optional since_id filter
 \i sql/fork_session.sql

--- a/sql/migrate_command_leases.sql
+++ b/sql/migrate_command_leases.sql
@@ -1,0 +1,9 @@
+-- Add executor leases without disrupting existing installations. Running rows
+-- from pre-lease executors are immediately reclaimable because their lease is
+-- NULL.
+ALTER TABLE commands ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMP;
+ALTER TABLE commands ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMP;
+ALTER TABLE commands ADD COLUMN IF NOT EXISTS worker_id TEXT;
+
+CREATE INDEX IF NOT EXISTS commands_running_lease_idx
+  ON commands (lease_expires_at) WHERE status = 'running';

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ import pytest
 SQL_FILES = (
     "sql/init_schema.sql",
     "sql/migrate_session_identity.sql",
+    "sql/migrate_command_leases.sql",
     "sql/submit_command.sql",
     "sql/latest_output.sql",
     "sql/fork_session.sql",

--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -134,7 +134,7 @@ def test_run_subprocess_rejects_reserved_snapshot_variables(
 def test_handle_command_uses_combined_output(monkeypatch):
     captured = {}
 
-    def fake_run_subprocess(command, cwd, env):
+    def fake_run_subprocess(command, cwd, env, lease_refresh=None):
         return 1, "stdout+stderr"
 
     def fake_update_command(conn, cmd_id, status, output, exit_code):
@@ -310,7 +310,7 @@ def test_handle_command_cd_absolute_outside_root_fails(tmp_path, monkeypatch):
 def test_handle_command_cd_with_extra_args_runs_subprocess(monkeypatch):
     captured: dict = {}
 
-    def fake_run_subprocess(command, cwd, env):
+    def fake_run_subprocess(command, cwd, env, lease_refresh=None):
         captured['command'] = command
         return 0, ''
 
@@ -418,6 +418,7 @@ def test_main_closes_connection_on_keyboard_interrupt(monkeypatch):
 
     monkeypatch.setattr('workers.executor_agent.get_conn', fake_get_conn)
     monkeypatch.setattr('workers.executor_agent.setup_listener', lambda conn: None)
+    monkeypatch.setattr('workers.executor_agent.recover_worker_commands', lambda conn: 0)
     monkeypatch.setattr('workers.executor_agent.fetch_pending', fake_fetch_pending)
     monkeypatch.setattr('workers.executor_agent.wait_for_notify', lambda conn, timeout: None)
 
@@ -425,3 +426,24 @@ def test_main_closes_connection_on_keyboard_interrupt(monkeypatch):
         workers.executor_agent.main()
 
     assert closed
+
+
+def test_run_subprocess_refreshes_lease(monkeypatch, tmp_path):
+    monkeypatch.setattr(workers.executor_agent, "LEASE_REFRESH_SECONDS", 0.01)
+    refreshes = []
+
+    exit_code, _ = run_subprocess(
+        "sleep 0.1", str(tmp_path), None, lambda: refreshes.append(True) or True
+    )
+
+    assert exit_code == 0
+    assert refreshes
+
+
+def test_schema_and_migration_define_idempotent_lease_metadata():
+    init_schema = open("sql/init_schema.sql").read()
+    migration = open("sql/migrate_command_leases.sql").read()
+
+    for column in ("claimed_at", "lease_expires_at", "worker_id"):
+        assert column in init_schema
+        assert f"ADD COLUMN IF NOT EXISTS {column}" in migration

--- a/tests/test_executor_integration.py
+++ b/tests/test_executor_integration.py
@@ -10,7 +10,7 @@ import uuid
 
 import psycopg2
 
-from workers.executor_agent import fetch_pending, handle_command
+from workers.executor_agent import fetch_pending, handle_command, recover_worker_commands
 
 
 def _create_user_with_env(conn, cwd: str) -> tuple[str, str]:
@@ -128,3 +128,74 @@ def test_queued_commands_use_sequential_per_user_environment(
         status, output = cur.fetchone()
     assert status == "done"
     assert output.strip() == str(child)
+
+
+def test_expired_command_is_recovered_and_no_longer_blocks_session(db_conn):
+    user_id, session_id = _create_user_with_env(db_conn, "/tmp")
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT submit_command(%s, %s, %s)",
+            (user_id, session_id, "echo recovered"),
+        )
+        abandoned_id = cur.fetchone()[0]
+        cur.execute(
+            "SELECT submit_command(%s, %s, %s)",
+            (user_id, session_id, "echo subsequent"),
+        )
+        subsequent_id = cur.fetchone()[0]
+        cur.execute(
+            """UPDATE commands
+                  SET status='running', claimed_at=now() - interval '2 minutes',
+                      lease_expires_at=now() - interval '1 minute', worker_id='dead'
+                WHERE id=%s""",
+            (abandoned_id,),
+        )
+
+    worker = psycopg2.connect(db_conn.dsn)
+    try:
+        recovered = fetch_pending(worker, "fresh")
+        assert recovered["id"] == abandoned_id
+        handle_command(worker, recovered)
+
+        following = fetch_pending(worker, "fresh")
+        assert following["id"] == subsequent_id
+        handle_command(worker, following)
+    finally:
+        worker.close()
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, status, worker_id, lease_expires_at FROM commands "
+            "WHERE id IN (%s, %s) ORDER BY id",
+            (abandoned_id, subsequent_id),
+        )
+        rows = cur.fetchall()
+    assert [(row[0], row[1]) for row in rows] == [
+        (abandoned_id, "done"),
+        (subsequent_id, "done"),
+    ]
+    assert all(row[2] is None and row[3] is None for row in rows)
+
+
+def test_startup_recovers_commands_from_same_worker_identity(db_conn):
+    user_id, session_id = _create_user_with_env(db_conn, "/tmp")
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT submit_command(%s, %s, %s)",
+            (user_id, session_id, "echo restart"),
+        )
+        cmd_id = cur.fetchone()[0]
+        cur.execute(
+            """UPDATE commands SET status='running', claimed_at=now(),
+                      lease_expires_at=now() + interval '1 hour', worker_id='executor-a'
+                WHERE id=%s""",
+            (cmd_id,),
+        )
+
+    assert recover_worker_commands(db_conn, "executor-a") == 1
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT status, claimed_at, lease_expires_at, worker_id FROM commands WHERE id=%s",
+            (cmd_id,),
+        )
+        assert cur.fetchone() == ("pending", None, None, None)

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -17,9 +17,11 @@ import select
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import time
-from typing import Any, Dict
+import uuid
+from typing import Any, Callable, Dict
 
 from psycopg2 import sql, errors
 from psycopg2.extras import RealDictCursor
@@ -38,6 +40,13 @@ TERMINATION_GRACE_SECONDS = 0.5
 PIPE_DRAIN_TIMEOUT_SECONDS = 0.5
 RESERVED_COMMAND_ENV = frozenset({"DATABASE_URL", "PG_CONN"})
 DEFAULT_COMMAND_PATH = "/usr/local/bin:/usr/bin:/bin"
+LEASE_SECONDS = float(os.getenv("COMMAND_LEASE_SECONDS", "60"))
+LEASE_REFRESH_SECONDS = float(
+    os.getenv("COMMAND_LEASE_REFRESH_SECONDS", str(max(1.0, LEASE_SECONDS / 3)))
+)
+WORKER_ID = os.getenv("EXECUTOR_WORKER_ID") or (
+    f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4()}"
+)
 
 
 def _update_channel_config(conn, channel: str) -> None:
@@ -103,7 +112,31 @@ def wait_for_notify(conn, timeout: float) -> None:
         conn.notifies.clear()
 
 
-def fetch_pending(conn) -> Dict[str, Any] | None:
+def recover_worker_commands(conn, worker_id: str = WORKER_ID) -> int:
+    """Release commands belonging to a previous instance of this worker.
+
+    ``EXECUTOR_WORKER_ID`` should be a stable, unique deployment identity. At
+    startup, a new instance with that identity makes work left by its dead
+    predecessor eligible immediately rather than waiting for lease expiry.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE commands
+               SET status = 'pending', claimed_at = NULL,
+                   lease_expires_at = NULL, worker_id = NULL
+             WHERE status = 'running' AND worker_id = %s
+            """,
+            (worker_id,),
+        )
+        recovered = cur.rowcount
+    conn.commit()
+    if recovered:
+        logging.warning("Recovered %s command(s) left by worker %s", recovered, worker_id)
+    return recovered
+
+
+def fetch_pending(conn, worker_id: str = WORKER_ID) -> Dict[str, Any] | None:
     """Claim the next command while holding a session-level session lock.
 
     The advisory lock remains held after this function commits and is released
@@ -114,6 +147,17 @@ def fetch_pending(conn) -> Dict[str, Any] | None:
     """
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
         cur.execute("BEGIN;")
+        # Requeue abandoned work first so it no longer blocks later commands
+        # in the same session. NULL leases are rows created by older workers.
+        cur.execute(
+            """
+            UPDATE commands
+               SET status = 'pending', claimed_at = NULL,
+                   lease_expires_at = NULL, worker_id = NULL
+             WHERE status = 'running'
+               AND (lease_expires_at IS NULL OR lease_expires_at <= now())
+            """
+        )
         cur.execute("""
             SELECT c.id, c.user_id, c.session_id, c.command, e.cwd, e.env,
                    hashtextextended(c.session_id::text, 0) AS claim_lock_key
@@ -142,10 +186,13 @@ def fetch_pending(conn) -> Dict[str, Any] | None:
             cur.execute(
                 """
                 UPDATE commands
-                   SET status = 'running', cwd_snapshot = %s, env_snapshot = %s
+                   SET status = 'running', cwd_snapshot = %s, env_snapshot = %s,
+                       claimed_at = now(),
+                       lease_expires_at = now() + %s * interval '1 second',
+                       worker_id = %s
                  WHERE id = %s
                 """,
-                (row["cwd"], row["env"], row["id"]),
+                (row["cwd"], row["env"], LEASE_SECONDS, worker_id, row["id"]),
             )
             row["cwd_snapshot"] = row.pop("cwd")
             row["env_snapshot"] = row.pop("env")
@@ -157,7 +204,10 @@ def fetch_pending(conn) -> Dict[str, Any] | None:
 def update_command(conn, cmd_id: int, status: str, output: str, exit_code: int) -> None:
     with conn.cursor() as cur:
         cur.execute(
-            "UPDATE commands SET status=%s, output=%s, exit_code=%s, completed_at=now() WHERE id=%s",
+            """UPDATE commands
+                  SET status=%s, output=%s, exit_code=%s, completed_at=now(),
+                      claimed_at=NULL, lease_expires_at=NULL, worker_id=NULL
+                WHERE id=%s""",
             (status, output, exit_code, cmd_id),
         )
     conn.commit()
@@ -173,7 +223,26 @@ def update_cwd(conn, user_id, session_id, cwd: str) -> None:
     conn.commit()
 
 
-def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]:
+def refresh_lease(conn, cmd_id: int, worker_id: str = WORKER_ID) -> bool:
+    """Extend a command lease, returning false if this worker lost ownership."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """UPDATE commands
+                  SET lease_expires_at = now() + %s * interval '1 second'
+                WHERE id = %s AND status = 'running' AND worker_id = %s""",
+            (LEASE_SECONDS, cmd_id, worker_id),
+        )
+        refreshed = cur.rowcount == 1
+    conn.commit()
+    return refreshed
+
+
+def run_subprocess(
+    command: str,
+    cwd: str,
+    env_snapshot: Any,
+    lease_refresh: Callable[[], bool] | None = None,
+) -> tuple[int, str]:
     # Never inherit the worker's environment: it contains the database DSN and
     # may contain unrelated orchestration credentials.
     env: Dict[str, str] = {
@@ -252,9 +321,14 @@ def run_subprocess(command: str, cwd: str, env_snapshot: Any) -> tuple[int, str]
     termination_deadline = None
     drain_deadline = None
     fds = [proc.stdout, proc.stderr]
+    next_lease_refresh = time.monotonic() + LEASE_REFRESH_SECONDS
 
     while fds:
         now = time.monotonic()
+        if lease_refresh is not None and now >= next_lease_refresh:
+            if not lease_refresh():
+                logging.error("Command lease was lost while subprocess was active")
+            next_lease_refresh = now + LEASE_REFRESH_SECONDS
         if now >= deadline and not timed_out:
             if os.name == "posix":
                 try:
@@ -401,7 +475,10 @@ def _handle_command(conn, row: Dict[str, Any]) -> None:
 
     try:
         exit_code, output = run_subprocess(
-            command, row["cwd_snapshot"], row["env_snapshot"]
+            command,
+            row["cwd_snapshot"],
+            row["env_snapshot"],
+            lambda: refresh_lease(conn, row["id"]),
         )
     except Exception as exc:
         logging.exception(
@@ -433,6 +510,7 @@ def main() -> None:
     conn = get_conn()
     try:
         setup_listener(conn)
+        recover_worker_commands(conn)
         while True:
             row = fetch_pending(conn)
             if row:


### PR DESCRIPTION
### Motivation

- Prevent live commands from being claimed twice and make abandoned work reclaimable by adding explicit lease metadata and a recovery path.  
- Allow long-running subprocesses to keep ownership of a claimed job via a heartbeat so another worker does not steal it mid-execution.  
- Make the schema change safe for existing installations via an idempotent migration and provide tests that exercise recovery and queue unblocking.

### Description

- Add `claimed_at`, `lease_expires_at`, and `worker_id` columns to `commands` and a partial index for efficient discovery of expired leases in `sql/init_schema.sql` and an idempotent migration in `sql/migrate_command_leases.sql`.  
- Update `workers/executor_agent.py` to assign a renewable lease when claiming work, atomically requeue expired/legacy `running` rows before selection, clear lease metadata on terminal updates via `update_command`, and expose `COMMAND_LEASE_SECONDS`, `COMMAND_LEASE_REFRESH_SECONDS`, and `EXECUTOR_WORKER_ID` configuration.  
- Implement `refresh_lease` and refresh the lease periodically while `run_subprocess` is active, and add `recover_worker_commands` to reclaim commands left by a previous instance with the same `EXECUTOR_WORKER_ID` at startup.  
- Add unit and integration tests plus README docs: update `tests/test_executor_agent.py` and `tests/test_executor_integration.py` to cover heartbeat-refresh behavior, idempotent migration presence, expired-command recovery that unblocks a same-session queued command, and startup recovery for a stable worker identity, and document lease configuration in `README.md`.

### Testing

- Ran `pytest` (`python -m pytest -q`): `52 passed, 23 skipped`.  
- Compiled sources with `python -m py_compile` for `workers/executor_agent.py`, `tests/test_executor_agent.py`, and `tests/test_executor_integration.py` with no syntax errors.  
- Ran `git diff --check` with no reported problems.  
- PostgreSQL-dependent tests were exercised in the integration suite when `TEST_DATABASE_URL` is available; when not configured those tests are skipped (reflected in the skipped count above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cd6272f18832899667cff0a9892cf)