### PR TITLE
Add command lease metadata, recovery, and keepalive for quiet subprocesses

### DIFF
--- a/tests/test_executor_agent.py
+++ b/tests/test_executor_agent.py
@@ -440,6 +440,25 @@ def test_run_subprocess_refreshes_lease(monkeypatch, tmp_path):
     assert refreshes
 
 
+def test_run_subprocess_refreshes_lease_after_output_pipes_close(
+    monkeypatch, tmp_path
+):
+    """A quiet process must retain its lease until the process itself exits."""
+    monkeypatch.setattr(workers.executor_agent, "LEASE_REFRESH_SECONDS", 0.01)
+    refreshes = []
+    command = (
+        "python3 -c 'import os,time; os.close(1); os.close(2); time.sleep(0.2)'"
+    )
+
+    exit_code, output = run_subprocess(
+        command, str(tmp_path), None, lambda: refreshes.append(True) or True
+    )
+
+    assert exit_code == 0
+    assert output == ""
+    assert refreshes
+
+
 def test_schema_and_migration_define_idempotent_lease_metadata():
     init_schema = open("sql/init_schema.sql").read()
     migration = open("sql/migrate_command_leases.sql").read()

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -323,7 +323,10 @@ def run_subprocess(
     fds = [proc.stdout, proc.stderr]
     next_lease_refresh = time.monotonic() + LEASE_REFRESH_SECONDS
 
-    while fds:
+    # A process can close both output streams and continue doing work. Keep
+    # driving its timeout and lease heartbeat until it actually exits rather
+    # than blocking in ``wait()`` with an unrefreshed lease.
+    while fds or proc.poll() is None:
         now = time.monotonic()
         if lease_refresh is not None and now >= next_lease_refresh:
             if not lease_refresh():
@@ -360,7 +363,11 @@ def run_subprocess(
         if drain_deadline is not None:
             next_event = drain_deadline
         select_timeout = max(0.0, min(0.1, next_event - now))
-        ready, _, _ = select.select(fds, [], [], select_timeout)
+        if fds:
+            ready, _, _ = select.select(fds, [], [], select_timeout)
+        else:
+            time.sleep(select_timeout)
+            ready = []
         for fd in ready:
             chunk = fd.read1(4096)
             if not chunk:


### PR DESCRIPTION
### Motivation

- Prevent live commands from being double-claimed by adding renewable leases and worker identity metadata to `commands`.
- Make existing installations safe to upgrade by providing an idempotent migration for the new lease columns and index.
- Ensure long-running or quiet subprocesses keep their lease heartbeats even after they close `stdout`/`stderr`, and recover work left by a dead/stable worker identity at startup.

### Description

- Extended schema in `sql/init_schema.sql` to include `claimed_at`, `lease_expires_at`, and `worker_id` on `commands` and added `commands_running_lease_idx` to index running rows by lease expiry.
- Added an idempotent migration `sql/migrate_command_leases.sql` using `ADD COLUMN IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` so upgrades do not disrupt existing installations.
- Added `recover_worker_commands` to `workers/executor_agent.py` to reclaim `running` commands that belong to a previously-started instance with the same `EXECUTOR_WORKER_ID` at startup.
- Modified `fetch_pending` to atomically requeue rows whose lease is expired (or `NULL` for pre-lease rows) before selecting pending work, and to set `claimed_at`, `lease_expires_at`, and `worker_id` when claiming a row.
- Added `refresh_lease` and updated `update_command` to clear lease metadata (`claimed_at`, `lease_expires_at`, `worker_id`) when a command reaches a terminal state.
- Hardened `run_subprocess` to: continue enforcing timeouts and invoking the provided lease-refresh callback until the process itself exits (even if both output pipes close), and to sleep when no output file descriptors remain so the lease heartbeat still runs.
- Added unit/regression coverage in `tests/test_executor_agent.py` (`test_run_subprocess_refreshes_lease_after_output_pipes_close`) for the pipe-closure case, and exercised schema/migration assertions for the lease columns; integration tests in `tests/test_executor_integration.py` cover expired-lease recovery and startup recovery by worker identity.

### Testing

- Ran unit test suite with `pytest -q`, result: 53 passed, 23 skipped (PostgreSQL-dependent tests were skipped because `TEST_DATABASE_URL` was not configured). 
- Ran bytecode checks with `python -m compileall -q workers tests`, which succeeded. 
- Ran repository checks with `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cecc98e1883289e9d84834fdd3795)