### PR TITLE
Fix executor command-claim bugs and align stale tests with session sc…

### DIFF
--- a/tests/test_cleanup_agent.py
+++ b/tests/test_cleanup_agent.py
@@ -113,46 +113,51 @@ def test_cleanup_once_deletes_only_old_terminal_commands(conn):
         cur.execute(
             "INSERT INTO users (id, username) VALUES (%s, %s)", (uid_str, "deluser")
         )
+        cur.execute(
+            "INSERT INTO environments (user_id) VALUES (%s) RETURNING session_id",
+            (uid_str,),
+        )
+        session_id = cur.fetchone()[0]
         # Old + done -> deleted
         cur.execute(
-            "INSERT INTO commands (user_id, command, submitted_at, status) "
-            "VALUES (%s, 'old-done', now() - interval '100 days', 'done') RETURNING id",
-            (uid_str,),
+            "INSERT INTO commands (user_id, session_id, command, submitted_at, status) "
+            "VALUES (%s, %s, 'old-done', now() - interval '100 days', 'done') RETURNING id",
+            (uid_str, session_id),
         )
         old_done_id = cur.fetchone()[0]
         # Old + failed -> deleted
         cur.execute(
-            "INSERT INTO commands (user_id, command, submitted_at, status) "
-            "VALUES (%s, 'old-failed', now() - interval '100 days', 'failed') RETURNING id",
-            (uid_str,),
+            "INSERT INTO commands (user_id, session_id, command, submitted_at, status) "
+            "VALUES (%s, %s, 'old-failed', now() - interval '100 days', 'failed') RETURNING id",
+            (uid_str, session_id),
         )
         old_failed_id = cur.fetchone()[0]
         # Recent terminal commands -> preserved (still within retention window)
         cur.execute(
-            "INSERT INTO commands (user_id, command, submitted_at, status) "
-            "VALUES (%s, 'recent-done', now(), 'done') RETURNING id",
-            (uid_str,),
+            "INSERT INTO commands (user_id, session_id, command, submitted_at, status) "
+            "VALUES (%s, %s, 'recent-done', now(), 'done') RETURNING id",
+            (uid_str, session_id),
         )
         recent_done_id = cur.fetchone()[0]
         cur.execute(
-            "INSERT INTO commands (user_id, command, submitted_at, status) "
-            "VALUES (%s, 'recent-failed', now(), 'failed') RETURNING id",
-            (uid_str,),
+            "INSERT INTO commands (user_id, session_id, command, submitted_at, status) "
+            "VALUES (%s, %s, 'recent-failed', now(), 'failed') RETURNING id",
+            (uid_str, session_id),
         )
         recent_failed_id = cur.fetchone()[0]
         # Non-terminal commands are preserved regardless of age
         cur.execute(
-            "INSERT INTO commands (user_id, command, submitted_at, status) "
-            "VALUES (%s, 'old-pending', now() - interval '100 days', 'pending') "
+            "INSERT INTO commands (user_id, session_id, command, submitted_at, status) "
+            "VALUES (%s, %s, 'old-pending', now() - interval '100 days', 'pending') "
             "RETURNING id",
-            (uid_str,),
+            (uid_str, session_id),
         )
         old_pending_id = cur.fetchone()[0]
         cur.execute(
-            "INSERT INTO commands (user_id, command, submitted_at, status) "
-            "VALUES (%s, 'old-running', now() - interval '100 days', 'running') "
+            "INSERT INTO commands (user_id, session_id, command, submitted_at, status) "
+            "VALUES (%s, %s, 'old-running', now() - interval '100 days', 'running') "
             "RETURNING id",
-            (uid_str,),
+            (uid_str, session_id),
         )
         old_running_id = cur.fetchone()[0]
 
@@ -184,29 +189,31 @@ def test_cleanup_expires_original_but_retains_newer_replay(conn):
             INSERT INTO environments (user_id, cwd, env, updated_at)
             VALUES (%s, '/tmp/stale', '{"stale": true}'::jsonb,
                     now() - interval '100 days')
+            RETURNING session_id
             """,
             (uid_str,),
         )
+        session_id = cur.fetchone()[0]
         cur.execute(
             """
-            INSERT INTO commands (user_id, command, output, submitted_at, status)
-            VALUES (%s, 'original command', 'original output',
+            INSERT INTO commands (user_id, session_id, command, output, submitted_at, status)
+            VALUES (%s, %s, 'original command', 'original output',
                     now() - interval '100 days', 'done')
             RETURNING id
             """,
-            (uid_str,),
+            (uid_str, session_id),
         )
         original_id = cur.fetchone()[0]
         cur.execute(
             """
             INSERT INTO commands
-                (user_id, command, output, submitted_at, status,
+                (user_id, session_id, command, output, submitted_at, status,
                  replay_of_command_id, replay_run_id)
-            VALUES (%s, 'original command', 'replay output', now(), 'done',
+            VALUES (%s, %s, 'original command', 'replay output', now(), 'done',
                     %s, %s)
             RETURNING id
             """,
-            (uid_str, original_id, str(uuid.uuid4())),
+            (uid_str, session_id, original_id, str(uuid.uuid4())),
         )
         replay_id = cur.fetchone()[0]
 
@@ -244,12 +251,13 @@ def test_cleanup_once_resets_env(conn):
             "INSERT INTO users (id, username) VALUES (%s, %s)", (uid_str, "testuser")
         )
         cur.execute(
-            "INSERT INTO environments (user_id, cwd, env, updated_at) VALUES (%s, %s, %s::jsonb, now() - interval '100 days')",
+            "INSERT INTO environments (user_id, cwd, env, updated_at) VALUES (%s, %s, %s::jsonb, now() - interval '100 days') RETURNING session_id",
             (uid_str, "/tmp", '{"k":1}'),
         )
+        session_id = cur.fetchone()[0]
         cur.execute(
-            "INSERT INTO commands (user_id, command, submitted_at, status) VALUES (%s, 'ls', now() - interval '100 days', 'done')",
-            (uid_str,),
+            "INSERT INTO commands (user_id, session_id, command, submitted_at, status) VALUES (%s, %s, 'ls', now() - interval '100 days', 'done')",
+            (uid_str, session_id),
         )
 
     cleanup_once(conn, 90)
@@ -271,12 +279,13 @@ def test_cleanup_once_resets_multiple_envs(conn, caplog):
                 (uid, f"multiuser{i}"),
             )
             cur.execute(
-                "INSERT INTO environments (user_id, cwd, env, updated_at) VALUES (%s, %s, %s::jsonb, now() - interval '100 days')",
+                "INSERT INTO environments (user_id, cwd, env, updated_at) VALUES (%s, %s, %s::jsonb, now() - interval '100 days') RETURNING session_id",
                 (uid, "/tmp", '{"k":1}'),
             )
+            session_id = cur.fetchone()[0]
             cur.execute(
-                "INSERT INTO commands (user_id, command, submitted_at, status) VALUES (%s, 'ls', now() - interval '100 days', 'done')",
-                (uid,),
+                "INSERT INTO commands (user_id, session_id, command, submitted_at, status) VALUES (%s, %s, 'ls', now() - interval '100 days', 'done')",
+                (uid, session_id),
             )
     caplog.set_level(logging.INFO)
     cleanup_once(conn, 90)

--- a/tests/test_executor_integration.py
+++ b/tests/test_executor_integration.py
@@ -6,11 +6,40 @@ the unit tests in ``test_executor_agent.py`` stub out. They require
 ``TEST_DATABASE_URL`` and are skipped otherwise.
 """
 
+import os
+import pwd
+import shutil
 import uuid
 
 import psycopg2
+import pytest
 
+import workers.executor_agent
 from workers.executor_agent import fetch_pending, handle_command, recover_worker_commands
+
+
+@pytest.fixture(autouse=True)
+def configured_executor(monkeypatch, tmp_path):
+    """Configure the executor's account and allowlist for real command runs."""
+    account = pwd.getpwuid(os.geteuid())
+    if account.pw_uid == 0:
+        account = pwd.getpwnam("nobody")
+        tmp_path.chmod(0o777)
+        parent = tmp_path.parent
+        while parent != parent.parent and parent != parent.parent.parent:
+            parent.chmod(0o755)
+            if parent == tmp_path.parents[2]:
+                break
+            parent = parent.parent
+    monkeypatch.setenv("EXECUTOR_USER", account.pw_name)
+    command_path = workers.executor_agent.DEFAULT_COMMAND_PATH
+    commands = [
+        shutil.which(name, path=command_path)
+        for name in ("echo", "pwd", "python3", "sleep")
+    ]
+    monkeypatch.setenv(
+        "EXECUTOR_ALLOWED_COMMANDS", os.pathsep.join(filter(None, commands))
+    )
 
 
 def _create_user_with_env(conn, cwd: str) -> tuple[str, str]:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -166,7 +166,7 @@ def test_submit_command_requires_existing_user(conn):
     missing_user_id = str(uuid.uuid4())
     with conn.cursor() as cur:
         with pytest.raises(psycopg2.Error) as exc_info:
-            cur.execute("SELECT submit_command(%s, %s, %s)", (missing_user_id, uuid.uuid4(), "echo nope"))
+            cur.execute("SELECT submit_command(%s, %s, %s)", (missing_user_id, str(uuid.uuid4()), "echo nope"))
     err = exc_info.value
     assert "Unknown user_id" in str(err)
     assert err.pgcode == '22023'
@@ -340,7 +340,7 @@ def test_replay_session_unknown_user_raises(conn):
     missing_user = str(uuid.uuid4())
     with conn.cursor() as cur:
         with pytest.raises(psycopg2.Error) as exc_info:
-            cur.execute("SELECT replay_session(%s, %s, %s)", (missing_user, uuid.uuid4(), 1))
+            cur.execute("SELECT replay_session(%s, %s, %s)", (missing_user, str(uuid.uuid4()), 1))
     assert exc_info.value.pgcode == "22023"
 
 

--- a/workers/executor_agent.py
+++ b/workers/executor_agent.py
@@ -24,7 +24,7 @@ import uuid
 from typing import Any, Callable, Dict
 
 from psycopg2 import sql, errors
-from psycopg2.extras import RealDictCursor
+from psycopg2.extras import Json, RealDictCursor
 
 from workers.db import get_conn
 
@@ -180,7 +180,7 @@ def fetch_pending(conn, worker_id: str = WORKER_ID) -> Dict[str, Any] | None:
         row = cur.fetchone()
         if row:
             cur.execute("SELECT pg_try_advisory_lock(%s)", (row["claim_lock_key"],))
-            if not cur.fetchone()[0]:
+            if not cur.fetchone()["pg_try_advisory_lock"]:
                 conn.commit()
                 return None
             cur.execute(
@@ -192,7 +192,7 @@ def fetch_pending(conn, worker_id: str = WORKER_ID) -> Dict[str, Any] | None:
                        worker_id = %s
                  WHERE id = %s
                 """,
-                (row["cwd"], row["env"], LEASE_SECONDS, worker_id, row["id"]),
+                (row["cwd"], Json(row["env"]), LEASE_SECONDS, worker_id, row["id"]),
             )
             row["cwd_snapshot"] = row.pop("cwd")
             row["env_snapshot"] = row.pop("env")


### PR DESCRIPTION
…hema

- executor_agent.fetch_pending used tuple indexing on a RealDictCursor result for pg_try_advisory_lock, raising KeyError on every claim; index by column name instead.
- The refreshed env snapshot (a dict from JSONB) was passed straight into the UPDATE and rejected with 'can't adapt type dict'; wrap it in Json.
- Update cleanup tests to attach commands to a valid session_id now that the column is NOT NULL, and give the executor integration tests the same EXECUTOR_USER / EXECUTOR_ALLOWED_COMMANDS fixture the unit tests use.
- Pass session ids as strings in two error-path function tests so psycopg2 can adapt them.


Claude-Session: https://claude.ai/code/session_01V6C2eZvbEWJxAWqMxFPLHi